### PR TITLE
corrected formatting and href issues. progress on #160.

### DIFF
--- a/src/components/Footer/index.js
+++ b/src/components/Footer/index.js
@@ -1,3 +1,5 @@
+/* eslint-disable max-len */
+
 import { Link } from 'react-router-dom'
 import React from 'react'
 import useStyles from './styles.js'
@@ -57,9 +59,8 @@ const Footer = () => {
       </div>
       <div className={classes.noteContainer}>
         <p className={classes.note}>The Civic Tech Index is an open-source project.</p>
-        <p className={classes.note}>You can download or contribute to the code on&nbsp;
-          <a href='https://github.com/civictechindex' className={classes.link}>GitHub.</a></p>
-        <p className={classes.note}><a href="#" className={classes.link}>View Attributions</a></p>
+        <p className={classes.note}>You can download or contribute to the code on <a href='https://github.com/civictechindex' className={classes.link}>GitHub</a>.</p>
+        <p className={classes.note}><a href="/" className={classes.link}>View Attributions</a></p>
       </div>
     </div>
   )


### PR DESCRIPTION
Adjusted href "#" to "/" on View Attributions line (restores link display on site and clears href warning on compile, however, link is non-functional). Condensed github link line to a single line and reformatted to account for space and period. max-len warning in ESLint bypassed temporarily for discussion on Tuesday.

This fixes some issues found in PR #204 post review and post merge. package and package-lock reverts are addressed in PR #208.