### PR TITLE
Ignore serviceWorker.js for linting purposes

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,0 @@
-src/serviceWorker.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+src/serviceWorker.js

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,6 +8,7 @@
      "plugin:react/recommended",
      "react-app"
    ],
+  "ignorePatterns": "src/serviceWorker.js",
    "overrides": [
      {
        "files": [


### PR DESCRIPTION
Closes #269 

Because this file is "owned" by create-react-act, we can assume it is thoroughly linted, tested, and good to go without us dealing with it, so we can "ignore" this file.