### PR TITLE
Add useTheme() to MUI doc

### DIFF
--- a/UI-THEME-STYLES.md
+++ b/UI-THEME-STYLES.md
@@ -29,7 +29,7 @@ As one example, MUI's `<Button>` has been customized significantly in our theme.
 
 The file `src/styles.js` is another place to make global changes, in two ways.
 
-As a first example, the class `'.card240'` is defined in the `'@global'` section of this document.
+As a first example, the class `'.card240'` (placeholder name) is defined in the `'@global'` section of this document.
 That means that `className='card240'` is available for any element throughout the project.
 
 Secondly, styling objects can also be added at the top level, not under '@global':
@@ -59,13 +59,7 @@ Feel free to put anything we need here, but avoid putting something here that is
 The file `src/styles.css` is a standard CSS file used throughout the project.
 Use this for traditional CSS declarations, but this method is not preferred.
 This file needs to be imported into any component that uses its classes.
-[ _TODO: Is this true?_ ]
-
-### Is there any other way?
-
-There are many other ways to apply global or multi-file styling changes.
-For the time being, let's avoid the other ways without first coming to an agreement amongst the dev team.
-[ _TODO: This is how to proceed, yes?_ ]
+[ _TODO: Is this true? TODO: Are we going to keep this file?_ ]
 
 ## Local Styling
 
@@ -115,3 +109,9 @@ const XYZcomponent = () => {
   )
 }
 ```
+
+## Is there any other way?
+
+There are many other ways to apply styling changes.
+For the time being, let's avoid other ways without first coming to an agreement amongst the dev team.
+If you want to use another method of stying, please bring up the topic in team meetings!

--- a/UI-THEME-STYLES.md
+++ b/UI-THEME-STYLES.md
@@ -69,22 +69,40 @@ For the time being, let's avoid the other ways without first coming to an agreem
 
 ## Local Styling
 
-At times it will make sense to have a local piece of styling.
-We have a preference to **avoid in-line styling like this**, especially if you hard-code locally some value that actually applies project-wide:
+At times it will make sense to have a local piece of in-line styling.
 
 ```javascript
 <Typography variant='h3' style={{ color: '#D8D8D8' }}>
 ```
 
-Typically, we prefer to re-use design, so make this a global change if possible. However, in the case that there is a valid reason to have a local piece of stying just for one component, unless it's a simple static piece of code we prefer `makeStyles` and `useStyles` to be able to reference the theme settings or to use any variable. So **the preferred approach is along these lines**:
+We have a preference to **avoid in-line styling** like this, especially if you hard-code some value that actually applies project-wide. Rather, we prefer to re-use design, so make this a global change if possible. **Avoid using hard-coded colors, fonts, and other styling in individual components.** There may be cases where a simple piece of local styling makes sense, but be sure it's the best way to go.
+
+In the case that there is a valid reason to have a local piece of stying just for one component, and it's not a simple static piece of code, we prefer `useTheme()` or `makeStyles()`/`useStyles()` to be able to reference the theme settings or to implement dynamic styling. **The two preferred approaches are along the lines of the following examples.**
+
+### useTheme()
+
+```javascript
+import { darken, useTheme } from '@material-ui/core/styles'
+
+const XYZcomponent = () => {
+  const theme = useTheme();
+  const localColor = darken(theme.palette.grey[300], 0.5)
+
+  return (
+    <Typography variant='h3' style={{ color: localColor }}>
+  )
+}
+```
+
+### makeStyles()
 
 ```javascript
 import { makeStyles } from '@material-ui/core/styles'
 
 const useStyles = makeStyles((theme) => ({
   foo: {
-    color: theme.palette.grey[300],
-    bar: ({ baz }) => baz
+    bar: (props) => props.baz * 2,
+    color: theme.palette.grey[300]
   }
 }))
 


### PR DESCRIPTION
Update UI-THEME-STYLES.md
 
Add a `useTheme()` paragraph to Local Styling section. 
Other small rewrites of the document, after discussing MUI with dev team yesterday.

