### PR TITLE
Update Cypress coverage (TagCreator affliated)

### DIFF
--- a/cypress/integration/pages/tag-creator.spec.js
+++ b/cypress/integration/pages/tag-creator.spec.js
@@ -1,6 +1,15 @@
 describe('Tag Creator (Tag Generator)', () => {
-  const TEST_URL = 'https://github.com/civictechindex/CTI-website-frontend.git'
-  const TEST_TAGS = [
+  const AFFILIATED_ORGANIZATION = 'Code for Boston'
+  const AFFILIATED_TEST_URL = 'codeforboston / voiceapp311'
+  const AFFILIATED_TEST_TAGS = [
+    'code-for-boston',
+    'code-for-america',
+    'alexa',
+    'trash',
+  ]
+
+  const UNAFFILIATED_TEST_URL = 'https://github.com/civictechindex/CTI-website-frontend.git'
+  const UNAFFILIATED_TEST_TAGS = [
     'civictechindex',
     'hack-for-la',
     'code-for-america',
@@ -10,12 +19,8 @@ describe('Tag Creator (Tag Generator)', () => {
     'opensource',
   ]
 
-  before(() => {
-    cy.visit('/tag-generator')
-  })
-
   beforeEach(() => {
-    // cy.visit('/tag-generator')
+    cy.visit('/tag-generator')
   })
 
   it('loads', () => {
@@ -23,15 +28,30 @@ describe('Tag Creator (Tag Generator)', () => {
       .contains('Tag Generator')
   })
 
-  it('loads correct tags for `civictechindex/CTI-website-frontend` repo - unaffiliated', () => {
-    cy.get('[data-cy=radio-unaffiliated]').click()
-    cy.get('#container-unaffiliated').within(() => {
-      cy.get('#repository-url').click().type(TEST_URL).type('{enter}')
+  it('loads correct 4 tags for `codeforboston/voiceapp311` - affiliated', () => {
+    cy.get('[data-cy=radio-affiliated]').click()
+    cy.get('#container-affiliated').within(() => {
+      cy.get('#organization').click().type(AFFILIATED_ORGANIZATION).type('{downarrow}{enter}')
+      cy.get('#repository-url', { force: true }).click().type(AFFILIATED_TEST_URL).type('{enter}')
       cy.get('[data-cy=current-tags]').within(() => {
         cy.get('[data-cy=topic-tag] span').each(($el, index, $list) => {
           const innerText = $el.text()
-          expect(TEST_TAGS.indexOf(innerText)).to.be.eq(index)
-          expect(TEST_TAGS.indexOf(innerText)).to.be.gt(-1)
+          expect(AFFILIATED_TEST_TAGS.indexOf(innerText)).to.be.eq(index)
+          // expect(AFFILIATED_TEST_TAGS.indexOf(innerText)).to.be.gt(-1)
+        })
+      })
+    })
+  })
+
+  it('loads correct 7 tags for `civictechindex/CTI-website-frontend` - unaffiliated', () => {
+    cy.get('[data-cy=radio-unaffiliated]').click()
+    cy.get('#container-unaffiliated').within(() => {
+      cy.get('#repository-url').click().type(UNAFFILIATED_TEST_URL).type('{enter}')
+      cy.get('[data-cy=current-tags]').within(() => {
+        cy.get('[data-cy=topic-tag] span').each(($el, index, $list) => {
+          const innerText = $el.text()
+          expect(UNAFFILIATED_TEST_TAGS.indexOf(innerText)).to.be.eq(index)
+          // expect(UNAFFILIATED_TEST_TAGS.indexOf(innerText)).to.be.gt(-1)
         })
       })
     })

--- a/package-lock.json
+++ b/package-lock.json
@@ -5594,9 +5594,9 @@
       "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk="
     },
     "cypress": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-6.3.0.tgz",
-      "integrity": "sha512-Ec6TAFOxdSB2HPINNJ1f7z75pENXcfCaQkz+A9j0eGSvusFJ2NNErq650DexCbNJAnCQkPqXB4XPH9kXnSQnUA==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-6.4.0.tgz",
+      "integrity": "sha512-SrsPsZ4IBterudkoFYBvkQmXOVxclh1/+ytbzpV8AH/D2FA+s2Qy5ISsaRzOFsbQa4KZWoi3AKwREmF1HucYkg==",
       "dev": true,
       "requires": {
         "@cypress/listr-verbose-renderer": "^0.4.1",
@@ -5613,6 +5613,7 @@
         "cli-table3": "~0.6.0",
         "commander": "^5.1.0",
         "common-tags": "^1.8.0",
+        "dayjs": "^1.9.3",
         "debug": "^4.1.1",
         "eventemitter2": "^6.4.2",
         "execa": "^4.0.2",
@@ -5627,7 +5628,7 @@
         "lodash": "^4.17.19",
         "log-symbols": "^4.0.0",
         "minimist": "^1.2.5",
-        "moment": "^2.27.0",
+        "moment": "^2.29.1",
         "ospath": "^1.2.2",
         "pretty-bytes": "^5.4.1",
         "ramda": "~0.26.1",
@@ -5878,6 +5879,12 @@
       "version": "1.30.1",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
       "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
+      "dev": true
+    },
+    "dayjs": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.4.tgz",
+      "integrity": "sha512-RI/Hh4kqRc1UKLOAf/T5zdMMX5DQIlDxwUe3wSyMMnEbGunnpENCdbUgM+dW7kXidZqCttBrmw7BhN4TMddkCw==",
       "dev": true
     },
     "debug": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@cypress/instrument-cra": "^1.4.0",
     "babel-plugin-istanbul": "^6.0.0",
     "babel-plugin-transform-class-properties": "^6.24.1",
-    "cypress": "^6.3.0",
+    "cypress": "^6.4.0",
     "eslint": "^6.8.0",
     "eslint-plugin-cypress": "^2.11.2",
     "eslint-plugin-react": "^7.22.0",

--- a/src/pages/TagCreator/index.js
+++ b/src/pages/TagCreator/index.js
@@ -114,13 +114,13 @@ const OrganizationSelectorSection = ({ orgs, setOrgName, handleEnter, repository
  * https://github.com/civictechindex/CTI-website-frontend.git
  * git@github.com:civictechindex/CTI-website-frontend.git
  * github.com/civictechindex/CTI-website-frontend
- * civictechindex/CTI-website-frontend
+ * civictechindex / CTI-website-frontend
  */
 const getRepositoryUrlPath = (url) => {
-  let result = url
+  let result = url.replace(/ /g, '')
   const prefix = /^(?:https?:\/\/)?github\.com\/|git@github\.com:/
   const suffix = /\.git$/
-  result = url.replace(prefix, '')
+  result = result.replace(prefix, '')
   result = result.replace(suffix, '')
   return result
 }


### PR DESCRIPTION
A few more changes to Cypress test coverage.

- On TagCreator, allow pasting from GitHub repo name as it's found in the upper right of repo page. (When you copy/paste from GitHub, it can be in this format, too: `civictechindex / CTI-website-frontend` with spaces.)
- Add to TagCreator spec a test for affiliated org (Code for Boston, chosen at random)
- Update Cypress --> 6.4.0

---

See coverage report at https://lcov-report.kevinashworth.vercel.app/

These changes improve coverage from

80.54% Statements 385/478 
70.29% Branches 97/138 
73.15% Functions 109/149 
81.09% Lines 373/460 

to what you see now

81.48% Statements 396/486 
71.74% Branches 99/138 
74.67% Functions 112/150 
82.05% Lines 384/468 

