### PR TITLE
bypass eslint for console statements on two files. closes #255. close…

### DIFF
--- a/src/components/ContributorThumbnail.js
+++ b/src/components/ContributorThumbnail.js
@@ -49,7 +49,9 @@ const Thumbnail = ({ thumbnailInfo, organization }) => {
           src={thumbnailInfo.imageUrl}
           className={classes.thumbnailImage}
           onError={(e) =>
+            // eslint-disable-next-line no-console
             console.log(`${e}: error with ${organization.name} image`)
+            // Before MVP: Refactor as on-website error/generic case.
           }
           alt={`${organization.name} logo`}
           loading="lazy"

--- a/src/components/ParentContributor.js
+++ b/src/components/ParentContributor.js
@@ -19,10 +19,12 @@ export const ParentContributor = ({ dropdownLength, children }) => {
               src={"https://codeforall.org/assets/images/homepage/logo.png"}
               className={classes.codeForAllThumbnailImage}
               onError={(e) =>
+                // eslint-disable-next-line no-console
                 console.log(
                   e,
                   `error with 'Code For All' ParentContributor Component`
                 )
+                // Before MVP: Refactor as on-website error message / generic case.
               }
               alt="code for all logo"
               loading="lazy"


### PR DESCRIPTION
Bypass eslint for console statements on two files. closes #255. closes #257:

- Adds Ignore single line rule for each line of code.

- Prior to MVP, both of these console.log statements should be either replaced by handling behavior within the UI (generic image, not found message, etc.), or removed. Comments added accordingly.