### PR TITLE
Add Colors guide

### DIFF
--- a/src/guides/colors.js
+++ b/src/guides/colors.js
@@ -1,0 +1,339 @@
+import React from "react"
+import Box from "@material-ui/core/Box"
+import Card from "@material-ui/core/Card"
+import CardContent from "@material-ui/core/CardContent"
+import Divider from "@material-ui/core/Divider"
+import Grid from "@material-ui/core/Grid"
+import Paper from "@material-ui/core/Paper"
+import Typography from "@material-ui/core/Typography"
+import { makeStyles, useTheme } from "@material-ui/core/styles"
+
+const useStyles = makeStyles((theme) => ({
+  box: {
+    backgroundColor: (props) => props.color,
+    height: "112px",
+    width: "272px",
+  },
+  colorName: {
+    color: theme.palette.secondary.dark,
+  },
+  mono: {
+    color: theme.palette.text.disabled,
+    fontFamily: theme.typography.secondFontFamily.fontFamily,
+  },
+}))
+
+const ColorBox = ({ color }) => {
+  const classes = useStyles({ color })
+  return (
+    <Box>
+      <Paper className={classes.box} elevation="0" square variant="outlined" />
+    </Box>
+  )
+}
+
+const CardFooter = ({ children }) => {
+  return (
+    <>
+      <Typography variant="body2" color="primary">
+        &nbsp
+      </Typography>
+      <Divider />
+      <Typography variant="body2" color="primary">
+        Code
+      </Typography>
+      <Divider />
+      <Box>{children}</Box>
+    </>
+  )
+}
+
+const ShowColors = () => {
+  const classes = useStyles()
+  const theme = useTheme()
+  return (
+    <>
+      <Typography variant="h1">Colors</Typography>
+      <Typography variant="h2" color="secondary" gutterBottom>
+        Primary
+      </Typography>
+      <Grid container spacing={2}>
+        <Grid item xs={6} md={3}>
+          <Card className="card242">
+            <CardContent>
+              <ColorBox color={theme.palette.primary.main} />
+              <Typography variant="h6" className={classes.colorName}>
+                Dark Blue
+              </Typography>
+              <Typography variant="body2" color="secondary">
+                Color: #0F1D2F
+              </Typography>
+              <Typography variant="body1">
+                Primary text color throughout site. Also used as footer
+                background.
+              </Typography>
+            </CardContent>
+            <CardFooter>
+              <Typography variant="body1" className={classes.mono}>
+                theme.palette.primary.main
+              </Typography>
+              <Typography variant="body1" className={classes.mono}>
+                theme.palette.text.primary
+              </Typography>
+              <Typography variant="body1" className={classes.mono}>
+                theme.palette.text.dark
+              </Typography>
+              <Typography variant="body1" className={classes.mono}>
+                {`Typography color='primary'`}
+              </Typography>
+            </CardFooter>
+          </Card>
+        </Grid>
+        <Grid item xs={6} md={3}>
+          <Card className="card242">
+            <CardContent>
+              <ColorBox color={theme.palette.secondary.dark} />
+              <Typography variant="h6" className={classes.colorName}>
+                Teal
+              </Typography>
+              <Typography variant="body2" color="secondary">
+                Color: #004364
+              </Typography>
+              <Typography variant="body1">
+                Primary background color. Also used as heading color on light
+                backgrounds.
+              </Typography>
+            </CardContent>
+            <CardFooter>
+              <Typography variant="body1" className={classes.mono}>
+                theme.palette.secondary.dark
+              </Typography>
+              <Typography variant="body1" className={classes.mono}>
+                theme.palette.background.primary
+              </Typography>
+            </CardFooter>
+          </Card>
+        </Grid>
+        <Grid item xs={6} md={3}>
+          <Card className="card242">
+            <CardContent>
+              <ColorBox color={theme.palette.secondary.main} />
+              <Typography variant="h6" className={classes.colorName}>
+                Light Blue
+              </Typography>
+              <Typography variant="body2" color="secondary">
+                Color: #0D99C6
+              </Typography>
+              <Typography variant="body1">
+                Used for standard hyperlinks and primary buttons.
+              </Typography>
+            </CardContent>
+            <CardFooter>
+              <Typography variant="body1" className={classes.mono}>
+                theme.palette.secondary.main
+              </Typography>
+              <Typography variant="body1" className={classes.mono}>
+                {`Typography color='secondary'`}
+              </Typography>
+            </CardFooter>
+          </Card>
+        </Grid>
+        <Grid item xs={6} md={3}>
+          <Card className="card242">
+            <CardContent>
+              <ColorBox color={theme.palette.secondary.light} />
+              <Typography variant="h6" className={classes.colorName}>
+                Light Blue - Variant
+              </Typography>
+              <Typography variant="body2" color="secondary">
+                Color: #5FCAF9
+              </Typography>
+              <Typography variant="body1">
+                Used for hyperlinks and icons on dark backgrounds and the
+                footer.
+              </Typography>
+            </CardContent>
+            <CardFooter>
+              <Typography variant="body1" className={classes.mono}>
+                theme.palette.secondary.light
+              </Typography>
+              <Typography variant="body1" className={classes.mono}>
+                theme.palette.text.light
+              </Typography>
+            </CardFooter>
+          </Card>
+        </Grid>
+        <Grid item xs={6} md={3}>
+          <Card className="card242">
+            <CardContent>
+              <ColorBox color={theme.palette.warning.main} />
+              <Typography variant="h6" className={classes.colorName}>
+                Yellow
+              </Typography>
+              <Typography variant="body2" color="secondary">
+                Color: #FFE06D
+              </Typography>
+              <Typography variant="body1">
+                Used only for headers on primary backgrounds.
+              </Typography>
+            </CardContent>
+            <CardFooter>
+              <Typography variant="body1" className={classes.mono}>
+                theme.palette.warning.main
+              </Typography>
+              <Typography variant="body1" className={classes.mono}>
+                theme.palette.text.bright
+              </Typography>
+              <Typography variant="body1" className={classes.mono}>
+                {`Typography color='textPrimary'`}
+              </Typography>
+            </CardFooter>
+          </Card>
+        </Grid>
+        <Grid item xs={6} md={3}>
+          <Card className="card242">
+            <CardContent>
+              <ColorBox color={theme.palette.background.default} />
+              <Typography variant="h6" className={classes.colorName}>
+                White
+              </Typography>
+              <Typography variant="body2" color="secondary">
+                Color: #FEFEFE
+              </Typography>
+              <Typography variant="body1">
+                Used only for headers on primary backgrounds.
+              </Typography>
+            </CardContent>
+            <CardFooter>
+              <Typography variant="body1" className={classes.mono}>
+                theme.palette.background.default
+              </Typography>
+              <Typography variant="body1" className={classes.mono}>
+                theme.palette.text.secondary
+              </Typography>
+              <Typography variant="body1" className={classes.mono}>
+                Typography&nbspcolor={`'textSecondary'`}
+              </Typography>
+            </CardFooter>
+          </Card>
+        </Grid>
+      </Grid>
+      <Typography variant="h1" gutterBottom>
+        &nbsp
+      </Typography>
+      <Typography variant="h2" color="secondary" gutterBottom>
+        Secondary
+      </Typography>
+      <Grid container spacing={2}>
+        <Grid item xs={6} md={3}>
+          <Card className="card242">
+            <CardContent>
+              <ColorBox color={theme.palette.text.disabled} />
+              <Typography variant="h6" className={classes.colorName}>
+                Dark Gray
+              </Typography>
+              <Typography variant="body2" color="secondary">
+                Color: #6D6E74
+              </Typography>
+              <Typography variant="body1">
+                Stroke color for interactive elements and field forms. Also used
+                for secondary information such as labels and disabled states.
+              </Typography>
+            </CardContent>
+            <CardFooter>
+              <Typography variant="body1" className={classes.mono}>
+                theme.palette.text.disabled
+              </Typography>
+            </CardFooter>
+          </Card>
+        </Grid>
+        <Grid item xs={6} md={3}>
+          <Card className="card242">
+            <CardContent>
+              <ColorBox color={theme.palette.background.secondary} />
+              <Typography variant="h6" className={classes.colorName}>
+                Light Gray
+              </Typography>
+              <Typography variant="body2" color="secondary">
+                Color: #F2F2F2
+              </Typography>
+              <Typography variant="body1">
+                Secondary background color in place of white.
+              </Typography>
+            </CardContent>
+            <CardFooter>
+              <Typography variant="body1" className={classes.mono}>
+                theme.palette.background.secondary
+              </Typography>
+            </CardFooter>
+          </Card>
+        </Grid>
+        <Grid item xs={0} md={6} />
+        <Grid item xs={6} md={3}>
+          <Card className="card242">
+            <CardContent>
+              <ColorBox color={theme.palette.secondary.main} />
+              <Typography variant="h6" className={classes.colorName}>
+                Light Blue - Hover
+              </Typography>
+              <Typography variant="body2" color="secondary">
+                Color: #006B95
+              </Typography>
+              <Typography variant="body1">
+                Fill color for hovered primary buttons.
+              </Typography>
+            </CardContent>
+            <CardFooter>
+              <Typography variant="body1">(n/a)</Typography>
+            </CardFooter>
+          </Card>
+        </Grid>
+        <Grid item xs={6} md={3}>
+          <Card className="card242">
+            <CardContent>
+              <ColorBox color={theme.palette.error.main} />
+              <Typography variant="h6" className={classes.colorName}>
+                Red
+              </Typography>
+              <Typography variant="body2" color="secondary">
+                Color: #D20E0E
+              </Typography>
+              <Typography variant="body1">
+                Use for text label errors.
+              </Typography>
+            </CardContent>
+            <CardFooter>
+              <Typography variant="body1" className={classes.mono}>
+                theme.palette.error.main
+              </Typography>
+            </CardFooter>
+          </Card>
+        </Grid>
+        <Grid item xs={6} md={3}>
+          <Card className="card242">
+            <CardContent>
+              <ColorBox color="#551A8B" />
+              <Typography variant="h6" className={classes.colorName}>
+                Purple
+              </Typography>
+              <Typography variant="body2" color="secondary">
+                Color: #551A8B
+              </Typography>
+              <Typography variant="body1">
+                Used to denote visited links.
+              </Typography>
+            </CardContent>
+            <CardFooter>
+              <Typography variant="body1">(n/a)</Typography>
+            </CardFooter>
+          </Card>
+        </Grid>
+      </Grid>
+      <Typography variant="h1" gutterBottom>
+        &nbsp
+      </Typography>
+    </>
+  )
+}
+
+export default ShowColors

--- a/src/guides/index.js
+++ b/src/guides/index.js
@@ -8,6 +8,7 @@ import Select from '@material-ui/core/Select'
 import ExpandMoreRoundedIcon from '@material-ui/icons/ExpandMoreRounded'
 import { makeStyles } from '@material-ui/core/styles'
 import { Footer, Header } from '../components'
+import Colors from './colors'
 import TypeStandards from './type-standards'
 import Typography from './typography'
 
@@ -26,15 +27,16 @@ const useStyles = makeStyles((theme) => ({
 
 const Guides = () => {
   const classes = useStyles()
-  const [guide, setGuide] = React.useState('palette')
+  const [guide, setGuide] = React.useState('colors')
 
   const handleChange = (event) => {
     event.target.value && setGuide(event.target.value)
   }
 
   const components = {
+    colors: Colors,
     palette: TypeStandards,
-    typography: Typography
+    typography: Typography,
   }
   const Guide = components[guide]
 
@@ -43,7 +45,7 @@ const Guides = () => {
       <Header />
       <Container className={classes.container} maxWidth={false}>
         <Grid container spacing={2}>
-          <Grid item xs={3} className={classes.gridItem0}>
+          <Grid item xs={2} className={classes.gridItem0}>
             <FormControl>
               <InputLabel id='select-a-guide'>Guides</InputLabel>
               <Select
@@ -54,12 +56,13 @@ const Guides = () => {
                 IconComponent={ExpandMoreRoundedIcon}
               >
                 <MenuItem value=''><em>Select a Guide</em></MenuItem>
+                <MenuItem value='colors'>Colors</MenuItem>
                 <MenuItem value='palette'>Type Standards</MenuItem>
                 <MenuItem value='typography'>Typography</MenuItem>
               </Select>
             </FormControl>
           </Grid>
-          <Grid item xs={9} className={classes.gridItem1}>
+          <Grid item xs={10} className={classes.gridItem1}>
             <Guide />
           </Grid>
         </Grid>

--- a/src/theme-mui.js
+++ b/src/theme-mui.js
@@ -5,7 +5,9 @@ import { deepmerge } from '@material-ui/utils';
 const DARK_BLUE = '#0F1D2F'
 const TEAL = '#004364'
 const LIGHT_BLUE = '#0D99C6'
-const LIGHT_BLUE_VARIANT = '#0CB2E7'
+// const LIGHT_BLUE_VARIANT = '#0CB2E7'
+const LIGHT_BLUE_VARIANT = '#5FCAF9'
+const LIGHT_BLUE_HOVER = '#006B95'
 const YELLOW = '#FFE06D'
 const WHITE = '#FEFEFE'
 // Colors - Secondary
@@ -40,8 +42,8 @@ const themeSettings = {
           color: DARK_GRAY,
           backgroundColor: LIGHT_GRAY,
         },
-        '&:hover': {
-          backgroundColor: LIGHT_BLUE,
+        "&:hover": {
+          backgroundColor: LIGHT_BLUE_HOVER,
         },
         '&:active': {
           backgroundColor: LIGHT_BLUE,

--- a/src/theme-mui.js
+++ b/src/theme-mui.js
@@ -14,6 +14,7 @@ const WHITE = '#FEFEFE'
 const DARK_GRAY = '#6D6E74'
 const LIGHT_GRAY = '#F2F2F2'
 const RED = '#D20E0E'
+const PURPLE = '#551A8B'
 // Colors - Grey
 const GREY100 = '#F4F4F4' // default = #f5f5f5
 const GREY200 = '#E9E9E9' // default = #eeeeee
@@ -116,7 +117,7 @@ const themeSettings = {
           color: LIGHT_BLUE_VARIANT,
         },
         '& a:visited': {
-          color: 'auto',
+          color: PURPLE,
         },
       },
       colorPrimary: {


### PR DESCRIPTION
Add 'Colors' as a third guide on the 'Guides' page, the unlisted page at http://localhost:3000/guides

Based on Figma file 'Design System', with a change to LIGHT_BLUE_VARIANT and a new LIGHT_BLUE_HOVER