### PR TITLE
Refactor BottomCallToAction using Material-UI

### DIFF
--- a/src/components/BottomCallToAction.js
+++ b/src/components/BottomCallToAction.js
@@ -1,47 +1,32 @@
-/* eslint-disable sort-keys */
+import React from 'react';
+import { Box, Button, Grid, Typography, useTheme } from '@material-ui/core';
 
-import React from 'react'
-import { makeStyles } from '@material-ui/core/styles'
+const defaultBackgroundColor = 'transparent'; // see https://developer.mozilla.org/en-US/docs/Web/CSS/background-color - 'transparent' is initial value
+const defaultButtonHref = 'mailto:civictechindex@hackforla.org';
+const defaultButtonText = 'Contact Us';
 
-const useStyles = makeStyles(theme => ({
-  bottomCallToAction: {
-    display: 'flex',
-    flexDirection: 'column',
-    justifyContent: 'center',
-    alignItems: 'center',
-    minHeight: '15rem',
-    textAlign: 'center',
-  },
-  heading: {
-    fontFamily: theme.typography.fontFamily,
-    color: theme.palette.primary.main,
-    fontSize: '2.5rem',
-  },
-  button: {
-    fontFamily: theme.typography.fontFamily,
-    fontSize: theme.font.paragraph.fontSize,
-    fontWeight: 700,
-    backgroundColor: theme.palette.info.main,
-    padding: '1rem 5rem',
-    color: theme.palette.text.secondary,
-    border: 'none',
-    borderRadius: theme.button.borderRadius,
-    boxShadow: '0.1rem 0.1rem 10px #e0dede',
-    cursor: 'pointer',
-  },
-}))
-
-const BottomCallToAction = (props) => {
-  const { heading, buttonHref, buttonText } = props
-
-  const classes = useStyles()
+const BottomCallToAction = ({ color, buttonHref = defaultButtonHref, buttonText = defaultButtonText, heading }) => {
+  const theme = useTheme();
+  let bgColor = defaultBackgroundColor;
+  if (color === 'primary') {
+    bgColor = theme.palette.background.default;
+  }
+  const boxStyle = {
+    backgroundColor: bgColor,
+  };
 
   return (
-    <div className={classes.bottomCallToAction}>
-      <p className={classes.heading}>{heading}</p>
-      <a href={buttonHref}><button className={classes.button}>{buttonText}</button></a>
-    </div>
-  )
-}
+    <Box style={boxStyle} py={8}>
+      <Grid container direction='column' justify='center' alignItems='center' spacing={4}>
+        <Grid item>
+          <Typography variant='h2'>{heading}</Typography>
+        </Grid>
+        <Grid item>
+          <Button href={buttonHref}>{buttonText}</Button>
+        </Grid>
+      </Grid>
+    </Box>
+  );
+};
 
-export default BottomCallToAction
+export default BottomCallToAction;

--- a/src/pages/Contributors/index.js
+++ b/src/pages/Contributors/index.js
@@ -170,11 +170,7 @@ export default function Contributors({ match }) {
           </div>
         </div>
       </div>
-      <BottomCallToAction
-        heading="Want to add your organization?"
-        buttonHref="mailto:civictechindex@hackforla.org"
-        buttonText="Contact Us"
-      />
+      <BottomCallToAction heading="Want to add your organization?" color="primary" />
     </Container>
   );
 }

--- a/src/pages/Donation/index.js
+++ b/src/pages/Donation/index.js
@@ -51,11 +51,7 @@ const Donation = () => {
           src='./images/CTI-Donate-to-HfLA.gif' />
         <p className={classes.infoThank}>We appreciate your contribution.</p>
       </section>
-      <BottomCallToAction
-        heading='Want to support in other ways?'
-        buttonHref='mailto:civictechindex@hackforla.org'
-        buttonText='Contact Us'
-      />
+      <BottomCallToAction heading='Want to support in other ways?' />
     </Container>
   );
 }

--- a/src/pages/HowToUse/index.js
+++ b/src/pages/HowToUse/index.js
@@ -37,11 +37,7 @@ const HowToUse = () => {
         </div>
       </ol>
       <p className={classes.projectsFooter}>Don&apos;t forget to tell us when you&apos;ve submitted a project or if you would like your organization added to our network!</p>
-      <BottomCallToAction
-        heading='Submitted a project or still need help?'
-        buttonHref='mailto:civictechindex@hackforla.org'
-        buttonText='Contact Us'
-      />
+      <BottomCallToAction heading='Submitted a project or still need help?' />
     </Container>
   )
 }


### PR DESCRIPTION
Closes #328 

First refactor `BottomCallToAction.js`
- Rely on Material-UI and our theme and best practices, including for font, color, padding, spacing
- Add optional `color` prop to provide two different background color versions — just use the parent background color unless specifying the option `'primary'` to use a light background at the bottom of a dark page, but we could add other color combos
- Add default button href and text (because all 3 uses of this component are the same currently)

Then use refactored BottomCallToAction, relying on its default values and optional `color` prop
