### PR TITLE
Update .codeclimate.yml

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -11,7 +11,10 @@ checks:
   identical-code:
     enabled: true
 exclude_patterns:
-- "cypress/*"
+- "**/*.md"
+- "cypress/"
+- "public/"
+- "src/guides/"
 plugins: 
   eslint:
     enabled: true


### PR DESCRIPTION
Edit so we do not run Code Climate on markdown files (!). Nor run it our "guides" directory, which is for internal use only, or anything under "public," which is for assets, which never need testing.