### PR TITLE
Implement max-width of 1280 for content

### DIFF
--- a/src/components/Footer/index.js
+++ b/src/components/Footer/index.js
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 
 import Grid from '@material-ui/core/Grid'
 import useStyles from './styles'
+import { Container } from '@material-ui/core'
 
 const SocialSection = () => {
   const classes = useStyles()
@@ -40,7 +41,7 @@ const Footer = () => {
   const classes = useStyles()
 
   return (
-    <div>
+    <Container className={classes.containerFooter}>
       <Grid container className={classes.footerContainer}>
         <Grid item xs={0} sm={1} />
         <Grid item xs={4} sm={2}>
@@ -73,7 +74,7 @@ const Footer = () => {
           <p><a href="/">View Attributions</a></p>
         </Grid>
       </Grid>
-    </div>
+    </Container>
   )
 }
 

--- a/src/components/Footer/styles.js
+++ b/src/components/Footer/styles.js
@@ -1,8 +1,10 @@
 import { makeStyles } from '@material-ui/core/styles'
 
 const useStyles = makeStyles(theme => ({
-  footerContainer: {
+  containerFooter: {
     backgroundColor: theme.palette.grey[900],
+  },
+  footerContainer: {
     color: theme.palette.text.secondary,
     fontFamily: theme.typography.fontFamily,
     paddingTop: theme.spacing(4),

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -6,6 +6,7 @@ import { Link } from "react-router-dom";
 import NavLink from "./NavLink.js";
 import NavSublink from "./NavSublink.js";
 import { MenuRounded } from "@material-ui/icons";
+import { Container } from "@material-ui/core";
 const Header = () => {
   const classes = useStyles();
   const [isBurgerOpen, setIsBurgerOpen] = useState(null);
@@ -15,7 +16,7 @@ const Header = () => {
   };
 
   return (
-    <nav className={classes.nav}>
+    <Container className={classes.containerHeader}>
       <div className={classes.background}></div>
       <Link
         to="/home"
@@ -62,7 +63,7 @@ const Header = () => {
       <div onClick={handleClick} className={classes.mobileContainer}>
         <MenuRounded data-cy="menuIcon" fontSize="large" />
       </div>
-    </nav>
+    </Container>
   );
 };
 

--- a/src/components/Header/styles.js
+++ b/src/components/Header/styles.js
@@ -1,13 +1,9 @@
 import { makeStyles } from "@material-ui/core/styles";
 
 const useStyles = makeStyles((theme) => ({
-  nav: {
-    position: "relative",
-    height: "100px",
+  containerHeader: {
     backgroundColor: theme.palette.background.default,
-    fontSize: "16px",
-    fontFamily: theme.typography.fontFamily,
-    zIndex: "900",
+    height: "100px",
   },
   flexContainer: {
     position: "relative",

--- a/src/theme-mui.js
+++ b/src/theme-mui.js
@@ -129,7 +129,7 @@ const themeSettings = {
   },
   props: {
     MuiContainer: {
-      maxWidth: 'xl',
+      maxWidth: 'lg',
     },
     MuiInputAdornment: {
       disableTypography: true, // this changes startAdornment text color to primary


### PR DESCRIPTION
Closes #354 

* Change Container default maxWidth to 'lg' (1280) — This one change should be enough for the main contents of all pages to have the appropriate maxWidth.
* Use a Container as top-level Footer element  — It now matches the main contents of the pages.
* Use a Container as top-level Header element — This is incomplete! The "absolute" positioning of the logo gets in the way and it is too far left on wider screens. But the design of the Header in Figma is incomplete at narrower widths, so leave it at this change for now. (I suspect a significant refactor of the Header is yet to come but do not want to put off the other changes until then.)