### PR TITLE
Implement max-width of 1280 for content [v2]

### DIFF
--- a/src/components/BottomCallToAction.js
+++ b/src/components/BottomCallToAction.js
@@ -16,7 +16,7 @@ const BottomCallToAction = ({ color, buttonHref = defaultButtonHref, buttonText 
   };
 
   return (
-    <Box style={boxStyle} py={8}>
+    <Box style={boxStyle} py={8} mx={-3}>
       <Grid container direction='column' justify='center' alignItems='center' spacing={4}>
         <Grid item>
           <Typography variant='h2'>{heading}</Typography>

--- a/src/components/Footer/index.js
+++ b/src/components/Footer/index.js
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 
 import Grid from '@material-ui/core/Grid'
 import useStyles from './styles'
+import { Container } from '@material-ui/core'
 
 const SocialSection = () => {
   const classes = useStyles()
@@ -40,7 +41,7 @@ const Footer = () => {
   const classes = useStyles()
 
   return (
-    <div>
+    <Container className={classes.containerFooter}>
       <Grid container className={classes.footerContainer}>
         <Grid item xs={0} sm={1} />
         <Grid item xs={4} sm={2}>
@@ -73,7 +74,7 @@ const Footer = () => {
           <p><a href="/">View Attributions</a></p>
         </Grid>
       </Grid>
-    </div>
+    </Container>
   )
 }
 

--- a/src/components/Footer/styles.js
+++ b/src/components/Footer/styles.js
@@ -1,8 +1,10 @@
 import { makeStyles } from '@material-ui/core/styles'
 
 const useStyles = makeStyles(theme => ({
-  footerContainer: {
+  containerFooter: {
     backgroundColor: theme.palette.grey[900],
+  },
+  footerContainer: {
     color: theme.palette.text.secondary,
     fontFamily: theme.typography.fontFamily,
     paddingTop: theme.spacing(4),

--- a/src/pages/Contributors/styles.js
+++ b/src/pages/Contributors/styles.js
@@ -48,7 +48,8 @@ export const useStyle = makeStyles((theme) => ({
     },
   },
   unaffiliatedWrapper: {
-    width: '100%',
+    marginLeft: theme.spacing(-3),
+    marginRight: theme.spacing(-3),
     textAlign: 'center',
     backgroundColor: theme.palette.grey[100],
     padding: '1rem 0',

--- a/src/theme-mui.js
+++ b/src/theme-mui.js
@@ -129,7 +129,7 @@ const themeSettings = {
   },
   props: {
     MuiContainer: {
-      maxWidth: 'xl',
+      maxWidth: 'lg',
     },
     MuiInputAdornment: {
       disableTypography: true, // this changes startAdornment text color to primary


### PR DESCRIPTION
Closes #354

_Please note, this Pull Request does not modify the Header (unlike #356, "v1" of this PR)._

The main body of all pages and the Footer are set to the same maximum width:

1. Change Container default maxWidth to 'lg' (1280) — This one change should be enough for the main contents of all pages to have the appropriate maxWidth.
2. Use a Container as top-level Footer element — It now matches the main contents of the pages.

A couple of design sections are restored to full width of the main body, removing some visual padding they had around them:
1. Restore full-width design for BottomCallToAction — You can see this on Contributors, Donate, and HowToUse.
2. Restore full-width design for "Unaffiliated Contributors" block.