### PR TITLE
Add an Effect Hook to set document title on selected Routes

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { BrowserRouter, Redirect, Route, Switch } from 'react-router-dom';
 
 import Layout from './components/common/Layout';
@@ -17,6 +17,18 @@ import Placeholder from './pages/Placeholder';
 import Guides from './guides/';
 import useStyles from './styles';
 
+const RouteTitled = ({ title, ...rest }) => {
+  useEffect(() => {
+    if (title) {
+      document.title = 'Civic Tech Index — ' + title
+    }
+  })
+
+  return (
+    <Route {...rest} />
+  )
+}
+
 const App = () => {
   useStyles();
   return (
@@ -24,14 +36,14 @@ const App = () => {
       <Layout>
         <Switch>
           <Route exact path='/' component={Landing} />
-          <Route exact path='/about' component={About} />
-          <Route exact path='/adding-projects-to-the-index' component={HowToUse} />
-          <Route exact path='/contributors/:affiliation' component={Contributors} />
-          <Route exact path='/donate' component={Donation} />
+          <RouteTitled exact path='/about' component={About} title='About' />
+          <RouteTitled exact path='/adding-projects-to-the-index' component={HowToUse} title='How To Use' />
+          <RouteTitled exact path='/contributors/:affiliation' component={Contributors} title='Contributors' />
+          <RouteTitled exact path='/donate' component={Donation} title='Donate' />
           <Route exact path='/home' component={Home} />
-          <Route exact path='/projects' component={Projects} />
-          <Route exact path='/tag-generator' component={TagCreator} />
-          <Route exact path='/radicalcollaboration/:faq' component={Faq} />
+          <RouteTitled exact path='/projects' component={Projects} title='Search Projects' />
+          <RouteTitled exact path='/tag-generator' component={TagCreator} title='Tag Generator' />
+          <RouteTitled exact path='/radicalcollaboration/:faq' component={Faq} title='FAQs' />
           <Route path='/guides/:guide' component={Guides} />
           <Route path='/blank' component={Placeholder} />
           <Redirect from='/adding-projects' to='/adding-projects-to-the-index' />


### PR DESCRIPTION
Closes #362 

I chose to add an Effect Hook in `App.js` to set the document `title` on selected `Route`s. Puts `title` field in `head` of each page, to show title in browser tab.

If we want to modify more than just the `title` in the `head` of a page, like setting Open Graph `meta` tags, at that point then we could begin to use `Helmet` or some other package, but `Helmet` isn't needed just to set the `title`.