### PR TITLE
Refactor NavBreadcrumbs with Material UI (#327)

### DIFF
--- a/src/components/NavBreadcrumbs.js
+++ b/src/components/NavBreadcrumbs.js
@@ -32,6 +32,7 @@ export default function NavBreadcrumbs(props) {
   const linkProps = {
     color: linkColor,
     opacity: opacity,
+    textDecoration: 'none',
   }
   const activeLinkProps = {
     color: activeLinkColor,

--- a/src/components/NavBreadcrumbs.js
+++ b/src/components/NavBreadcrumbs.js
@@ -1,37 +1,73 @@
 import React from 'react';
-import { Breadcrumbs, Link, Typography } from '@material-ui/core';
-import { makeStyles } from '@material-ui/core/styles';
+import { Breadcrumbs, Typography } from '@material-ui/core';
+import { ThemeProvider, createMuiTheme } from '@material-ui/core/styles';
+import { NavLink } from 'react-router-dom';
 
-const useStyles = makeStyles({
-  root: props => ({
-    padding: '25px',
-    color: props.color,
-  }),
-});
+const DARK_BLUE = '#0F1D2F';
+const WHITE = '#FEFEFE';
+const DARK_GRAY = '#6D6E74';
+const FULL_OPAQUE = '100%';
+const SEMI_OPAQUE = '80%';
 
 /**
  * Navigation enabled breadcrumb.
  *
  * You may pass an array containing an object of
- * <NavBreadcrumbs crumbs={[{name: 'Home', href='/'}]}
+ * <NavBreadcrumbs crumbs={[{name: 'Home', href='/'}]} color="primary"
  * @param {Array} crumbs Array of name & href pairs.
- * @param {String} color Use color scheme
+ * @param {String} color Use primary or secondary color scheme
  */
 export default function NavBreadcrumbs(props) {
   const crumbs = props.crumbs;
-  const classes = useStyles(props)
+
+  let linkColor = WHITE;
+  let activeLinkColor = WHITE;
+  let opacity = SEMI_OPAQUE;
+  if (props.color === 'secondary') {
+    linkColor = DARK_GRAY;
+    activeLinkColor = DARK_BLUE;
+    opacity = FULL_OPAQUE;
+  }
+
+  const linkProps = {
+    color: linkColor,
+    opacity: opacity,
+  }
+  const activeLinkProps = {
+    color: activeLinkColor,
+    opacity: FULL_OPAQUE,
+  }
+
+  const theme = createMuiTheme({
+    overrides: {
+      MuiBreadcrumbs: {
+        ol: { padding: '32px' },
+        li: {
+          '& p': linkProps,
+          '& a:link': linkProps,
+          '& a:visited': linkProps,
+          '& a:hover': activeLinkProps,
+          '& a:active': activeLinkProps,
+          '& a:focus': activeLinkProps,
+        },
+        separator: linkProps,
+      },
+    },
+  });
 
   const displayCrumbs = crumbs.map((i,idx) => {
     if (i.href) {
-      return <Link key={idx} color="inherit" href={i.href}>{i.name}</Link>
+      return <NavLink key={idx} to={i.href}>{i.name}</NavLink>
     } else {
-      return <Typography key={idx} color="inherit">{i.name}</Typography>
+      return <Typography key={idx}>{i.name}</Typography>
     }
   });
 
   return (
-    <Breadcrumbs aria-label="breadcrumb" className={classes.root}>
-      {displayCrumbs}
-    </Breadcrumbs>
+    <ThemeProvider theme={theme}>
+      <Breadcrumbs aria-label="breadcrumb" maxItems={6}>
+        {displayCrumbs}
+      </Breadcrumbs>
+    </ThemeProvider>
   );
 }

--- a/src/components/NavBreadcrumbs.js
+++ b/src/components/NavBreadcrumbs.js
@@ -42,6 +42,7 @@ export default function NavBreadcrumbs(props) {
     overrides: {
       MuiBreadcrumbs: {
         root: {
+          fontFamily: 'Work Sans',
           padding: '32px',
           '& p': linkProps,
           '& a:link': linkProps,

--- a/src/components/NavBreadcrumbs.js
+++ b/src/components/NavBreadcrumbs.js
@@ -41,8 +41,8 @@ export default function NavBreadcrumbs(props) {
   const theme = createMuiTheme({
     overrides: {
       MuiBreadcrumbs: {
-        ol: { padding: '32px' },
-        li: {
+        root: {
+          padding: '32px',
           '& p': linkProps,
           '& a:link': linkProps,
           '& a:visited': linkProps,

--- a/src/components/NavBreadcrumbs.js
+++ b/src/components/NavBreadcrumbs.js
@@ -1,42 +1,37 @@
-import Breadcrumbs from '@material-ui/core/Breadcrumbs';
-import Link from '@material-ui/core/Link';
 import React from 'react';
-import Typography from '@material-ui/core/Typography';
+import { Breadcrumbs, Link, Typography } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
 
-const defaultBreadcrumb = {
-  fontFamily: 'Work Sans',
-  fontSize: '3vw',
-  fontStyle: 'normal',
-  fontWeight: '400',
-  letterSpacing: '0px',
-  lineHeight: '24px',
-  textAlign: 'left',
-}
+const useStyles = makeStyles({
+  root: props => ({
+    padding: '25px',
+    color: props.color,
+  }),
+});
 
 /**
  * Navigation enabled breadcrumb.
  *
  * You may pass an array containing an object of
- * <NavBreadcrumb crumbs={[{name: 'Home', href='/'}]}
+ * <NavBreadcrumbs crumbs={[{name: 'Home', href='/'}]}
  * @param {Array} crumbs Array of name & href pairs.
  * @param {String} color Use color scheme
  */
-export default function NavBreadcrumb(props) {
-  const crumbs = props.crumbs
+export default function NavBreadcrumbs(props) {
+  const crumbs = props.crumbs;
+  const classes = useStyles(props)
 
   const displayCrumbs = crumbs.map((i,idx) => {
     if (i.href) {
-      return <Link key={idx} color="inherit" href={i.href}> {i.name}</Link>
+      return <Link key={idx} color="inherit" href={i.href}>{i.name}</Link>
     } else {
       return <Typography key={idx} color="inherit">{i.name}</Typography>
     }
   });
 
   return (
-    <div style={defaultBreadcrumb}>
-      <Breadcrumbs aria-label="breadcrumb" style={{ color:props.color, padding: '25px' }}>
-        {displayCrumbs}
-      </Breadcrumbs>
-    </div>
+    <Breadcrumbs aria-label="breadcrumb" className={classes.root}>
+      {displayCrumbs}
+    </Breadcrumbs>
   );
 }

--- a/src/pages/Contributors/index.js
+++ b/src/pages/Contributors/index.js
@@ -8,7 +8,7 @@ import { Container, InputAdornment, TextField, Typography } from "@material-ui/c
 import Autocomplete from "@material-ui/lab/Autocomplete";
 import SearchRoundedIcon from '@material-ui/icons/SearchRounded';
 import BottomCallToAction from "../../components/BottomCallToAction";
-import NavBreadcrumb from "../../components/NavBreadcrumbs";
+import NavBreadcrumbs from "../../components/NavBreadcrumbs";
 import { DropdownArrow } from "../../components/DropdownArrow.js";
 import { AffiliatedOrganizations } from "./AffiliatedOrganizations";
 import { UnaffiliatedOrganizations } from "./UnaffiliatedOrganizations";
@@ -111,7 +111,7 @@ export default function Contributors({ match }) {
     <Container className='containerDefault'>
       <div className={classes.firstSectionWrapper}>
         <div className={classes.sectionContainer}>
-          <NavBreadcrumb
+          <NavBreadcrumbs
             crumbs={[
               { name: "Home", href: "/" },
               { name: "Contributors", href: "/contributors" },

--- a/src/pages/Contributors/index.js
+++ b/src/pages/Contributors/index.js
@@ -116,7 +116,6 @@ export default function Contributors({ match }) {
               { name: "Home", href: "/" },
               { name: "Contributors", href: "/contributors" },
             ]}
-            color="white"
           />
         </div>
         <div className={classes.sectionContainer}>

--- a/src/pages/Donation/index.js
+++ b/src/pages/Donation/index.js
@@ -21,7 +21,7 @@ const Donation = () => {
       <Grid container spacing={2}>
         <Grid item xs={false} sm={1} />
         <Grid item xs={12} sm={10}>
-          <NavBreadcrumbs crumbs={breadCrumbLinks} />
+          <NavBreadcrumbs crumbs={breadCrumbLinks} color="secondary"/>
         </Grid>
         <Grid item xs={false} sm={1} />
         <Grid item xs={false} sm={1} />

--- a/src/pages/Donation/index.js
+++ b/src/pages/Donation/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Grid, Container, Typography } from '@material-ui/core';
 
 import BottomCallToAction from '../../components/BottomCallToAction';
-import NavBreadCrumbs from "../../components/NavBreadcrumbs.js";
+import NavBreadcrumbs from "../../components/NavBreadcrumbs.js";
 
 import useStyles from './styles.js';
 
@@ -21,7 +21,7 @@ const Donation = () => {
       <Grid container spacing={2}>
         <Grid item xs={false} sm={1} />
         <Grid item xs={12} sm={10}>
-          <NavBreadCrumbs crumbs={breadCrumbLinks} />
+          <NavBreadcrumbs crumbs={breadCrumbLinks} />
         </Grid>
         <Grid item xs={false} sm={1} />
         <Grid item xs={false} sm={1} />

--- a/src/pages/Faq/index.js
+++ b/src/pages/Faq/index.js
@@ -57,7 +57,7 @@ export default function Faq({ match }) {
 
   return (
     <Container className='containerDefault'>
-      <NavBreadcrumbs crumbs={crumbs} color="#FEFEFE" />
+      <NavBreadcrumbs crumbs={crumbs} />
       <TitleSection>How can we help?</TitleSection>
       <SearchBar placeholder={"Search the knowledge base"} />
       {status === 'fetchedFaq' && <FAQCard title={"Frequently Asked Questions:"} faqs={data} />}

--- a/src/pages/Projects.js
+++ b/src/pages/Projects.js
@@ -3,7 +3,7 @@ import axios from "axios";
 import Container from "@material-ui/core/Container";
 import Grid from '@material-ui/core/Grid';
 
-import NavBreadcrumb from '../components/NavBreadcrumbs'
+import NavBreadcrumbs from '../components/NavBreadcrumbs'
 import ProjectCard from '../components/ProjectCard'
 import SearchBar from '../components/SearchBar'
 import '../styles.css'
@@ -51,7 +51,7 @@ const Projects = () => {
 
   return (
     <Container className='containerGray'>
-      <NavBreadcrumb crumbs={crumbs} color="#0F1D2F" />
+      <NavBreadcrumbs crumbs={crumbs} color="#0F1D2F" />
       <Grid Container>
         <Grid item xs={12}>
           <h1 style={{ color: "#004364" }}>Search Projects</h1>

--- a/src/pages/Projects.js
+++ b/src/pages/Projects.js
@@ -51,7 +51,7 @@ const Projects = () => {
 
   return (
     <Container className='containerGray'>
-      <NavBreadcrumbs crumbs={crumbs} color="#0F1D2F" />
+      <NavBreadcrumbs crumbs={crumbs} color="secondary" />
       <Grid Container>
         <Grid item xs={12}>
           <h1 style={{ color: "#004364" }}>Search Projects</h1>

--- a/src/pages/TagCreator/index.js
+++ b/src/pages/TagCreator/index.js
@@ -3,7 +3,7 @@ import axios from 'axios';
 import { Button, Chip, Container, Grid, TextField, Typography } from '@material-ui/core';
 import AssignmentTurnedInRoundedIcon from '@material-ui/icons/AssignmentTurnedInRounded';
 import Autocomplete from '@material-ui/lab/Autocomplete';
-import NavBreadcrumb from '../../components/NavBreadcrumbs'
+import NavBreadcrumbs from '../../components/NavBreadcrumbs'
 import { AffiliationQuestionSection } from "./AffilationQuestionSection";
 import orgs from './orgs.json';
 
@@ -169,7 +169,7 @@ const TagCreator = () => {
 
   return (
     <Container className='containerGray'>
-      <NavBreadcrumb crumbs={crumbs} color="#0F1D2F" />
+      <NavBreadcrumbs crumbs={crumbs} color="#0F1D2F" />
       <TitleSection />
       <Grid container>
         <AffiliationQuestionSection value={value} handleChange={handleChange} />

--- a/src/pages/TagCreator/index.js
+++ b/src/pages/TagCreator/index.js
@@ -169,7 +169,7 @@ const TagCreator = () => {
 
   return (
     <Container className='containerGray'>
-      <NavBreadcrumbs crumbs={crumbs} color="#0F1D2F" />
+      <NavBreadcrumbs crumbs={crumbs} color="secondary" />
       <TitleSection />
       <Grid container>
         <AffiliationQuestionSection value={value} handleChange={handleChange} />


### PR DESCRIPTION
* Use NavBreadcrumbs name more consistently across other components

* Use makeStyles to handle input props

* Simplify NavBreadcrumbs DOM