### PR TITLE
Update theme-mui.js

### DIFF
--- a/src/theme-mui.js
+++ b/src/theme-mui.js
@@ -181,11 +181,17 @@ const themeSettings = {
     MuiButtonBase: {
       disableRipple: true,
     },
+    MuiCard: {
+      elevation: 0,
+    },
     MuiContainer: {
       maxWidth: 'lg',
     },
     MuiInputAdornment: {
       disableTypography: true, // this changes startAdornment text color to primary
+    },
+    MuiPaper: {
+      elevation: 0,
     },
     MuiTextField: {
       variant: 'outlined',


### PR DESCRIPTION
By default, we don't want "elevation" on Card and Paper Material-UI components. (It's still available to customize on any use of Card or Paper, this just changes default from 1 to 0.)