### PR TITLE
Increase Cypress timeout to fetch affiliated orgs

### DIFF
--- a/cypress/integration/pages/contributors.spec.js
+++ b/cypress/integration/pages/contributors.spec.js
@@ -5,7 +5,7 @@ describe('Contributors Page', () => {
 
   it('wait for affiliated orgs to load', () => {
     cy.get('[class*=affiliatedOrgsContainer]').within(() => {
-      cy.get('[class*=containerDropdown]').should('have.length', 24)
+      cy.get('[class*=containerDropdown]', { timeout: 10000 }).should('have.length', 24);
     })
   })
 


### PR DESCRIPTION
A quick fix that increases the timeout of this Cypress test to 10 seconds, because loading affiliated orgs sometimes takes slightly too long for the test to pass reliably.