### PR TITLE
Update Volunteer with us link in Header and Footer

### DIFF
--- a/src/components/Footer/index.js
+++ b/src/components/Footer/index.js
@@ -61,7 +61,9 @@ const Footer = () => {
           <Link to='/adding-projects-to-the-index'>How to Do It</Link>
           <Link to='/donate'>Donate</Link>
           <Link to='/'>Share the CTI</Link>
-          <Link to='/'>Volunteer with Us</Link>
+          <a href='https://www.hackforla.org/projects/civic-tech-index' target='_blank'>
+            Volunteer with Us
+          </a>
           <Link to='/radicalcollaboration/faq'>FAQ</Link>
         </Grid>
         <Grid item xs={6} sm={2}>

--- a/src/components/Footer/index.js
+++ b/src/components/Footer/index.js
@@ -60,7 +60,7 @@ const Footer = () => {
           <Link to='/adding-projects-to-the-index'>How to Do It</Link>
           <Link to='/donate'>Donate</Link>
           <Link to='/'>Share the CTI</Link>
-          <a href='https://www.hackforla.org/projects/civic-tech-index' rel="noopener noreferrer">
+          <a href='https://www.hackforla.org/projects/civic-tech-index'>
             Volunteer with Us
           </a>
           <Link to='/radicalcollaboration/faq'>FAQ</Link>

--- a/src/components/Footer/index.js
+++ b/src/components/Footer/index.js
@@ -60,7 +60,7 @@ const Footer = () => {
           <Link to='/adding-projects-to-the-index'>How to Do It</Link>
           <Link to='/donate'>Donate</Link>
           <Link to='/'>Share the CTI</Link>
-          <a href='https://www.hackforla.org/projects/civic-tech-index' target='_blank'>
+          <a href='https://www.hackforla.org/projects/civic-tech-index' rel="noopener noreferrer">
             Volunteer with Us
           </a>
           <Link to='/radicalcollaboration/faq'>FAQ</Link>

--- a/src/components/Header/NavSublink.js
+++ b/src/components/Header/NavSublink.js
@@ -16,7 +16,7 @@ const styles = () => ({
 });
 const NavSublink = ({ heading, route, classes, isExternal=false }) => {
   const linkComponent = isExternal
-    ? <a href={route} rel="noopener noreferrer"
+    ? <a href={route}
         style={{ textDecoration: 'none' }}>
         <Typography>{heading}</Typography>
       </a>

--- a/src/components/Header/NavSublink.js
+++ b/src/components/Header/NavSublink.js
@@ -16,7 +16,7 @@ const styles = () => ({
 });
 const NavSublink = ({ heading, route, classes, isExternal=false }) => {
   const linkComponent = isExternal
-    ? <a href={route} target='_blank'
+    ? <a href={route} rel="noopener noreferrer"
         style={{ textDecoration: 'none' }}>
         <Typography>{heading}</Typography>
       </a>

--- a/src/components/Header/NavSublink.js
+++ b/src/components/Header/NavSublink.js
@@ -13,7 +13,19 @@ const styles = () => ({
     },
   },
 });
-const NavSublink = ({ heading, route, classes }) => {
+const NavSublink = ({ heading, route, classes, isExternal=false }) => {
+  const linkComponent = isExternal
+    ? <a href={route} target='_blank'
+        style={{ textDecoration: 'none' }}>
+        <Typography>{heading}</Typography>
+      </a>
+    : <Link
+        component={RouterLink}
+        to={route}
+        underline="none"
+        classes={{ root: classes.text }}
+      ><Typography>{heading}</Typography>
+      </Link>;
   return (
     <MenuItem
       data-cy="menuItem"
@@ -22,14 +34,7 @@ const NavSublink = ({ heading, route, classes }) => {
       classes={{ root: classes.menuitem }}
       ListItemClasses={{ root: classes.text }}
     >
-      <Link
-        component={RouterLink}
-        to={route}
-        underline="none"
-        classes={{ root: classes.text }}
-      >
-        <Typography>{heading}</Typography>
-      </Link>
+    {linkComponent}
     </MenuItem>
   );
 };

--- a/src/components/Header/NavSublink.js
+++ b/src/components/Header/NavSublink.js
@@ -17,7 +17,8 @@ const styles = () => ({
 const NavSublink = ({ heading, route, classes, isExternal=false }) => {
   const linkComponent = isExternal
     ? <a href={route}
-        style={{ textDecoration: 'none' }}>
+        style={{ textDecoration: 'none' }}
+      >
         <Typography>{heading}</Typography>
       </a>
     : <Link
@@ -25,7 +26,8 @@ const NavSublink = ({ heading, route, classes, isExternal=false }) => {
         to={route}
         underline="none"
         classes={{ root: classes.text }}
-      ><Typography>{heading}</Typography>
+      >
+        <Typography>{heading}</Typography>
       </Link>;
   return (
     <MenuItem

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -41,7 +41,7 @@ const Header = () => {
         <NavLink heading="Radical Collaboration" route="/radicalcollaboration">
           <NavSublink heading="Donate" route="/" />
           <NavSublink heading="Share the CTI" route="/radicalcollaboration/sharethecti" />
-          <NavSublink heading="Volunteer with us" route="/" />
+          <NavSublink heading="Volunteer with us" route="https://www.hackforla.org/projects/civic-tech-index" isExternal/>
           <NavSublink heading="FAQ" route="/radicalcollaboration/faq" />
         </NavLink>
         <NavLink heading="Organizations" route="/contributors/all">


### PR DESCRIPTION
Maintained the same style as before, but the "Volunteer with us" items now open a new tab at https://www.hackforla.org/projects/civic-tech-index

Reformatted NavSubLink to take external urls when provided an extra prop.

Header:
![image](https://user-images.githubusercontent.com/24858334/111082552-21c6cd80-84c6-11eb-9b72-97bd48668504.png)


Footer:
![image](https://user-images.githubusercontent.com/24858334/111082570-330fda00-84c6-11eb-8f1b-5753ffd7671d.png)
