### PR TITLE
Update NavLink.js

### DIFF
--- a/src/components/Header/NavLink.js
+++ b/src/components/Header/NavLink.js
@@ -53,9 +53,9 @@ const NavLink = ({ heading, route, children, classes }) => {
           }}
           classes={{ paper: classes.paper, list: classes.menu }}
           PopoverClasses={{ paper: classes.popover }}
-          elevation="0"
+          elevation={0}
         >
-          {children}
+          <div>{children}</div>
         </Menu>
       )}
     </>


### PR DESCRIPTION
Eliminate two causes of console warnings. 
1. The 'elevation' prop is a number, not a string.
2. Due to a bug referenced in the following links, put a 'div' around 'children'. See https://github.com/jcoreio/material-ui-popup-state/issues/11 and https://github.com/mui-org/material-ui/issues/15903#issuecomment-723807594