### PR TITLE
Update Faq.js with ESLint disable for now

### DIFF
--- a/src/pages/RadicalCollaboration/Faq.js
+++ b/src/pages/RadicalCollaboration/Faq.js
@@ -1,4 +1,5 @@
 /* eslint-disable sort-keys */
+/* eslint-disable react-hooks/exhaustive-deps */
 import React, { useCallback, useEffect, useState } from 'react';
 import Box from '@material-ui/core/Box';
 import Container from '@material-ui/core/Container';


### PR DESCRIPTION
Turn off ESLint warning `react-hooks/exhaustive-deps` (it causes S3 deploy to fail)