### PR TITLE
Fix crashing bug in AffliatedOrganizations

### DIFF
--- a/src/pages/Contributors/AffiliatedOrganizations.js
+++ b/src/pages/Contributors/AffiliatedOrganizations.js
@@ -4,40 +4,38 @@ import { ParentContributor } from "../../components/ParentContributor";
 import { ContributorThumbnail } from "../../components/ContributorThumbnail";
 import { useStyle } from "./styles.js";
 
-export const AffiliatedOrganizations = ({ affiliatedObject }) => {
+export const AffiliatedOrganizations = ({ organizations }) => {
   const classes = useStyle();
-  const parent = Object.keys(affiliatedObject)[0];
 
-  const numOfChildren = (organization) => {
-    if (affiliatedObject[organization.name]) {
-      return affiliatedObject[organization.name].length;
+  const parentOrg = organizations['Code for All'];
+
+  const getChildrenLength = (org) => {
+    if (organizations[org.name]) {
+      return organizations[org.name].length;
     } else {
       return 0;
     }
   };
-  return (parent ? (
-    <ParentContributor
-      dropdownLength={affiliatedObject["Code for All"].length}
-      isOpen={true}
-    >
-      {affiliatedObject["Code for All"].map((organization, idx) => {
-        return (
-          <Dropdown
-            organization={organization}
-            key={idx}
-            dropdownLength={numOfChildren(organization)}
-            isOpen={affiliatedObject["Code for All"].length < 3 ? true : false}
-          >
-            {affiliatedObject[organization.name] ? (
-              <div className={classes.affiliatedThumbnailsWrapper}>
-                {affiliatedObject[organization.name].map((child, idx) => (
-                  <ContributorThumbnail organization={child} key={idx} />
-                ))}
-              </div>
-            ) : null}
-          </Dropdown>
-        );
-      })}
-    </ParentContributor>
-  ) : null);
+
+  if (parentOrg) {
+    return (
+      <ParentContributor dropdownLength={parentOrg.length} isOpen={true}>
+        {parentOrg.map((org, i) => {
+          return (
+            <Dropdown organization={org} key={i} dropdownLength={getChildrenLength(org)} isOpen={parentOrg.length < 3 ? true : false}>
+              {organizations[org.name] ? (
+                <div className={classes.affiliatedThumbnailsWrapper}>
+                  {organizations[org.name].map((child, idx) => (
+                    <ContributorThumbnail organization={child} key={idx} />
+                  ))}
+                </div>
+              ) : null}
+            </Dropdown>
+          );
+        })}
+      </ParentContributor>
+    );
+  } else {
+    return null;
+  }
 };

--- a/src/pages/Contributors/index.js
+++ b/src/pages/Contributors/index.js
@@ -189,7 +189,7 @@ const Affiliation = ({ organizations, inputValue, classes, affiliation }) => {
     if (affiliation === "unaffiliated") {
       return <UnaffiliatedOrganizations unAffiliatedOrgs={organizations} />;
     } else {
-      return <AffiliatedOrganizations affiliatedObject={organizations} />;
+      return <AffiliatedOrganizations organizations={organizations} />;
     }
   }
 };


### PR DESCRIPTION
Closes #483  
- Fixes crashing bug by finding "Code for All" in the big object instead of assuming its index number
- Renames prop to the more-accurate term 'organizations'
- Slightly refactors the component, too
- Alas, this remains slow while awaiting the network request, but the bug does not crash the site anymore!