### PR TITLE
Makes all components/images full with on About page

### DIFF
--- a/src/components/PictureCard.js
+++ b/src/components/PictureCard.js
@@ -24,10 +24,10 @@ export default function PictureCard(props) {
   });
 
   return (
-    <>
-      <Grid container style={{ backgroundColor: "#F2F2F2" , margin: 'auto', maxWidth: '1200px', padding:'20px 0 20px 0' }}>
-        {displayCards}
-      </Grid>
-    </>
+    <div>
+        <Grid container style={{ backgroundColor: "#F2F2F2", margin: 'auto', padding:'20px 0 20px 0' }}>
+          {displayCards}
+        </Grid>
+    </div>
   );
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -99,7 +99,8 @@ p.white {
 
 @media screen and (min-width: 900px) {
 .getStartedCardDivStyle {
-    margin-top: 50px;
+    margin-top: 0px;
+    border: 0px;
 }
 }
 


### PR DESCRIPTION
Resolves #496
A further issue can be made to style Picture Cards reversing image with description as per figma