### PR TITLE
Fix useEffect warning in Faq.js (#460)

### DIFF
--- a/src/pages/RadicalCollaboration/Faq.js
+++ b/src/pages/RadicalCollaboration/Faq.js
@@ -58,6 +58,7 @@ const Faq = () => {
 
   useEffect(() => {
     getFAQData(query, false);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pageNum, largeScreen]);
 
   const handleInput = (event) => {


### PR DESCRIPTION
Closes #460 

* Add eslint ignore warning comment for react-hooks/exhaustive-deps