### PR TITLE
Adjust styling of Organizations search bar

### DIFF
--- a/src/pages/Contributors/OrganizationSearch.js
+++ b/src/pages/Contributors/OrganizationSearch.js
@@ -16,17 +16,24 @@ const useStyles = makeStyles((theme) => ({
     borderTopRightRadius: 4,
     color: theme.palette.text.secondary,
     height: 64,
+    [theme.breakpoints.down('sm')]: {
+      height: 48,
+    },
     '&:hover': {
       backgroundColor: theme.palette.secondary.main,
     },
   },
   input: {
-    "& .MuiOutlinedInput-root": {
+    '& .MuiOutlinedInput-root': {
       borderBottomLeftRadius: 4,
       borderBottomRightRadius: 0,
       borderTopLeftRadius: 4,
       borderTopRightRadius: 0,
       height: 64,
+      [theme.breakpoints.down('sm')]: {
+        height: 48,
+        padding: 4,
+      },
     },
   },
 }));

--- a/src/pages/Contributors/OrganizationSearch.js
+++ b/src/pages/Contributors/OrganizationSearch.js
@@ -1,10 +1,10 @@
-import React, { useState } from 'react'
-import { makeStyles } from "@material-ui/core";
+import React, { useState } from 'react';
+import { makeStyles } from '@material-ui/core';
 import Box from '@material-ui/core/Box';
 import Grid from '@material-ui/core/Grid';
 import IconButton from '@material-ui/core/IconButton';
-import TextField from "@material-ui/core/TextField";
-import Autocomplete from "@material-ui/lab/Autocomplete";
+import TextField from '@material-ui/core/TextField';
+import Autocomplete from '@material-ui/lab/Autocomplete';
 import SearchRoundedIcon from '@material-ui/icons/SearchRounded';
 
 const useStyles = makeStyles((theme) => ({

--- a/src/pages/Contributors/OrganizationSearch.js
+++ b/src/pages/Contributors/OrganizationSearch.js
@@ -16,6 +16,9 @@ const useStyles = makeStyles((theme) => ({
     borderTopRightRadius: 4,
     color: theme.palette.text.secondary,
     height: 64,
+    '&:hover': {
+      backgroundColor: theme.palette.secondary.main,
+    },
   },
   input: {
     "& .MuiOutlinedInput-root": {

--- a/src/pages/Contributors/OrganizationSearch.js
+++ b/src/pages/Contributors/OrganizationSearch.js
@@ -8,6 +8,10 @@ import Autocomplete from "@material-ui/lab/Autocomplete";
 import SearchRoundedIcon from '@material-ui/icons/SearchRounded';
 
 const useStyles = makeStyles((theme) => ({
+  root: {
+    paddingBottom: 32,
+    paddingTop: 16,
+  },
   icon: {
     backgroundColor: theme.palette.secondary.main,
     borderBottomLeftRadius: 0,
@@ -69,7 +73,7 @@ const OrganizationSearch = (props) => {
   };
 
   return (
-    <Grid container>
+    <Grid container className={classes.root}>
       <Grid item xs={1} />
       <Grid item xs={10}>
         <Box display='flex' alignItems='center'>

--- a/src/pages/Contributors/index.js
+++ b/src/pages/Contributors/index.js
@@ -300,10 +300,9 @@ export default function Contributors({ match }) {
           <Grid container>
             <TitleSection>Organizations</TitleSection>
             <Grid item xs={12}>
-              <Typography color='textSecondary' className={classes.textStyle}>Check out our partners who have contributed to the Civic Tech Index</Typography>
+              <Typography color='textSecondary' className={classes.textStyle} gutterBottom>Check out our partners who have contributed to the Civic Tech Index</Typography>
             </Grid>
             <Grid item xs={12}>
-
               <OrganizationSearch
                 options={organizationNamesList}
                 inputValue={inputValue}

--- a/src/pages/Contributors/styles.js
+++ b/src/pages/Contributors/styles.js
@@ -36,7 +36,7 @@ export const useStyle = makeStyles((theme) => ({
     textAlign:'center',
     marginTop: '-1rem',
     [theme.breakpoints.down('sm')]: {
-      fontSize: '14px',
+      fontSize: 16,
     },
   },
   


### PR DESCRIPTION
Closes #674  

- Change icon's hover bg color to ensure search icon doesn't disappear on hover
- Change height of search elements to 48 pixels on smaller screens
- Adjust vertical padding around search box
- Adjust "Check out..." text to 16 pixels, the size in Figma, at smaller screens
- Lint