### PR TITLE
Fix Jest tests

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -2,8 +2,8 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
-  const { getByText } = render(<App />);
-  const linkElement = getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+test('renders Civic Tech Index', () => {
+  const { getAllByText } = render(<App />);
+  const ctiElements = getAllByText(/Civic Tech Index/);
+  expect(ctiElements[0]).toBeInTheDocument();
 });

--- a/src/components/__fixtures__/links.json
+++ b/src/components/__fixtures__/links.json
@@ -8,7 +8,7 @@
     "organizationUrl": "https://github.com/code-for-canada"
   },
   {
-    "imageUrl": null,
+    "imageUrl": "/images/default-github-repo-image.png",
     "organizationUrl": "https://codeforpoland.org/"
   },
   {

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -5,3 +5,7 @@
  * learn more: https://github.com/testing-library/jest-dom
  */
 import '@testing-library/jest-dom/extend-expect';
+
+// https://stackoverflow.com/a/57312218/7082724
+const noop = () => {};
+Object.defineProperty(window, 'scrollTo', { value: noop, writable: true });


### PR DESCRIPTION
Summary:
This PR fixes our two Jest test files `App.test.js` and `src/components/__tests__/getOrganizationLinks.js`

More information:
We have mostly done testing with Cypress, but there have been two test files in our repo for Jest tests, or React Testing Library tests, using test setup scripts that come with Create React App. Both tests have been failing when you run `npm run test` from the command line.

This PR fixes both:

- `App.test.js` -- has been default code installed by CRA, so I updated it to simply look for 'Civic Tech Index' instead of 'learn react'
- `__tests__/getOrganizationLists.js` -- has been failing since a change was committed to load a default image when an org has none, and this PR updates it to look for the new default image

Also, I changed `setupTests.js` per StackOverflow to eliminate a weird console error about `window.scrollTo` that shouldn't really be an error for our purposes.