### PR TITLE
Refactor Search Page

### DIFF
--- a/src/components/Dropdown.js
+++ b/src/components/Dropdown.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import { ContributorThumbnail } from './ContributorThumbnail';
 import { DropdownArrow } from './DropdownArrow';
@@ -40,9 +40,10 @@ export const Dropdown = ({
   children,
   dropdownLength,
   isOpen,
+
 }) => {
-  const [openChild, setOpenChild] = useState(false);
-  const [colorStyle, setColor] = useState(false);
+  const [openChild, setOpenChild] = useState(isOpen ? true : false);
+  const [colorStyle, setColor] = useState(isOpen ? true : false);
   const classes = useStyles();
 
   const handleOpen = () => {
@@ -50,17 +51,23 @@ export const Dropdown = ({
     setColor(!colorStyle);
   };
 
+
+
+  useEffect(()=>{
+    setOpenChild(isOpen);
+    setColor(isOpen);
+  },[isOpen])
   return (
 
-    <Grid >
+    <Grid>
       {dropdownLength ? (
         <Grid item xs={10} className={clsx(classes.dropdown, { [classes.blueColor]: colorStyle === true })} >
           <Grid>
             <ContributorThumbnail organization={organization} dropdownLength={dropdownLength} isOpen={colorStyle} isChildThumbnail={false}/>
           </Grid>
           <Grid className={classes.flexGrid}></Grid>
-          <Grid item container className={classes.flexGrid} onClick={handleOpen} >
-            <DropdownArrow  open={openChild} handleArrow={handleOpen} />
+          <Grid item container className={classes.flexGrid} onClick={handleOpen}>
+            <DropdownArrow  open={openChild} setOpenFunction={setOpenChild}  handleArrow={handleOpen}/>
           </Grid>
         </Grid>
       ) : null}

--- a/src/components/DropdownArrow.js
+++ b/src/components/DropdownArrow.js
@@ -20,13 +20,15 @@ export const DropdownArrow  = ({ open,handleOpen }) => {
     },
   }));
 
-
   const classes = useStyles();
+  const handleClick = (setOpenFunction) => {
+    setOpenFunction((c) => !c);
+  };
 
   return (
     <>
       {open ? <ExpandLessRoundedIcon id = "dropdownChevron" className={classes.clickDropDown} onClick={handleOpen} />
-        : <ExpandMoreRoundedIcon id = "dropdownChevron" className={classes.chevron} onClick={handleOpen} />}
+        : <ExpandMoreRoundedIcon id = "dropdownChevron"  className={classes.chevron}  onClick={()=>handleClick}/>}
     </>
   );
 

--- a/src/pages/Contributors/AffiliatedOrganizations.js
+++ b/src/pages/Contributors/AffiliatedOrganizations.js
@@ -1,12 +1,14 @@
 /* eslint-disable max-lines-per-function */
 /* eslint-disable complexity */
 
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { Dropdown } from "../../components/Dropdown";
 import { ContributorThumbnail } from "../../components/ContributorThumbnail";
 import Button from '@material-ui/core/Button';
 import Grid from '@material-ui/core/Grid';
 import makeStyles from '@material-ui/core/styles/makeStyles'
+import Box from "@material-ui/core/Box";
+import { Typography } from "@material-ui/core";
 
 const useStyles = makeStyles((theme) => ({
   thumbnailGrid:{
@@ -64,15 +66,15 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-export const AffiliatedOrganizations = ({ organizations , inputValue, data, checkboxValue,handleClickArrow,arrow,affiliatedSepOpen }) => {
+export const AffiliatedOrganizations = ({ organizations , inputValue, data, checkboxValue }) => {
 
   const classes = useStyles();
   const parentfilterData = data;
   const [isChildThumbnail] = useState(true);
-  const parentOrg =organizations['Code for All'].filter(item => item);
+
   const getParentData = () => {
+    const parentOrg =organizations['Code for All'].filter(item => item);
     const parentdata = [];
-    let flag = false;
 
     parentOrg.forEach((data)=>{
       if (data.depth === 3){
@@ -85,7 +87,7 @@ export const AffiliatedOrganizations = ({ organizations , inputValue, data, chec
         if (inputValue !== '')
         {
           const newobj =  parentfilterData.find((d)=> data.path.includes(d.path) && d.depth === 3);
-          flag = true;
+
           const exist = parentdata.find((d)=> newobj.path === d.path);
           if (!exist){
             newobj['childNodes'] = [];
@@ -115,14 +117,16 @@ export const AffiliatedOrganizations = ({ organizations , inputValue, data, chec
       }
 
     })
-    if (flag){
-      inputValue = '';
-    }
     return parentdata
   }
 
 
   const [currentThumbnails, setCurrentThumbnails] = useState(getParentData);
+
+  useEffect(()=>{
+    setCurrentThumbnails(getParentData);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  },[inputValue, organizations,parentfilterData,checkboxValue])
 
   const getChildrenLength = (org) => {
     if (org.childNodes.length > 0) {
@@ -132,13 +136,14 @@ export const AffiliatedOrganizations = ({ organizations , inputValue, data, chec
     }
   };
 
+
   if (currentThumbnails &&  inputValue.length === 0) {
     return (
       <Grid className={classes.thumbnailGrid} dropdownlength={currentThumbnails.length}>
         {currentThumbnails.map((org, i) => {
           const childNode = org.isOpen ?  org.childNodes : org.childNodes.slice(0,8)
           return (
-            <Dropdown organization={org} key={`affiliatedThumbnailsWrapper_${i}`} dropdownLength={getChildrenLength(org)} isOpen={org.childNodes.length > 0 ? true : false}>
+            <Dropdown organization={org} key={`affiliatedThumbnailsWrapper_${i}`} dropdownLength={getChildrenLength(org)} isOpen={false}>
               <Grid container alignItems='center' style={{ margin:'auto' }} >
                 {childNode.length > 0 ? (
                   <Grid item container xs={10} className={classes.affiliatedThumbnailsWrapper}>
@@ -169,20 +174,43 @@ export const AffiliatedOrganizations = ({ organizations , inputValue, data, chec
     );
 
   }
-  else if (currentThumbnails && inputValue !== null) {
+  else if (currentThumbnails && inputValue !== null && inputValue.length > 0 && inputValue !== '') {
     return (
       <Grid className={classes.thumbnailGrid} dropdownLength={currentThumbnails.length}>
-        {currentThumbnails.map((searchDataItems, i) => {
+        {currentThumbnails.map((org, i) => {
+          // console.log(org.childNodes.length, "org.childNodes.length");
+          return (
+            <Dropdown organization={org} key={`affiliatedThumbnailsWrapper_${i}`} dropdownLength={getChildrenLength(org)} isOpen={org.childNodes.length <= 5 ? true : false}>
+              <Box className={classes.affiliatedThumbnailsWrapper}>
+                { org.childNodes.length === 0 ?
 
-          return (<Grid container className={classes.affiliatedThumbnailsWrapper} key={`affiliatedThumbnailsWrapper_${i}`}>
-            <Grid className={classes.afflnThumbnails} key={i}>
-              <ContributorThumbnail
-                organization={searchDataItems}
-                isChildThumbnail={isChildThumbnail} >
-              </ContributorThumbnail>
-            </Grid>
-          </Grid>
+                  <Typography className={classes.afflnThumbnails}>
+                    <ContributorThumbnail
+                      organization={org}
+                      isChildThumbnail= {isChildThumbnail}
+                    ></ContributorThumbnail>
+                  </Typography>
+
+
+                  :
+                  <>
+                    {org.childNodes.map((child, idx) => {
+
+                      return <Typography className={classes.afflnThumbnails} key={`affiliatedThumbnail_child_${i}_${idx}`}>
+                        <ContributorThumbnail
+                          organization={child}
+                          isChildThumbnail= {isChildThumbnail}
+                        ></ContributorThumbnail>
+                      </Typography>
+                    })}
+                  </>
+                }
+              </Box>
+            </Dropdown>
+
           );
+
+
         })}
       </Grid>
     );

--- a/src/pages/Contributors/index.js
+++ b/src/pages/Contributors/index.js
@@ -19,7 +19,6 @@ import Tab from "@material-ui/core/Tab";
 import Checkbox from '@material-ui/core/Checkbox';
 import FormGroup from "@material-ui/core/FormGroup";
 import FormControlLabel from "@material-ui/core/FormControlLabel";
-import { MuiThemeProvider, createMuiTheme } from "@material-ui/core/styles";
 import { Affiliated  } from "./Affiliated";
 import { UnaffiliatedOrganizations } from "./UnaffiliatedOrganizations";
 import OrganizationSearch from "./OrganizationSearch";
@@ -203,33 +202,7 @@ export default function Contributors({ match }) {
     };
   }
 
-  const theme = createMuiTheme({
 
-
-
-    overrides: {
-      MuiTab: {
-        "root": {
-          color: 'theme​.palette.​text.disabled',
-          fontSize: '32px',
-          fontWeight: 'bold',
-          textTransform: 'none',
-          display: "flex",
-
-          '&$selected': {
-            color: '#006B95',
-          },
-
-        },
-        wrapper: {
-          flexDirection: "row",
-          width: "auto",
-        },
-
-      },
-
-    },
-  });
 
   const [value, setValue] = React.useState(0);
   const handleChange = (event, newValue) => {
@@ -276,25 +249,20 @@ export default function Contributors({ match }) {
       </Box>
       <Box className='containerGray'>
         <Container>
-          <MuiThemeProvider theme={theme}>
-            <AppBar position="static" color="default" elevation={0}>
-              <Tabs
-                value={value}
-                onChange={handleChange}
-                variant="fullWidth"
-                className={classes.tabs}
-                classes={{ indicator: classes.indicator }}
-              >
+          <AppBar position="static" color="default" elevation={0}>
+            <Tabs
+              value={value}
+              onChange={handleChange}
+              variant="fullWidth"
+              className={classes.tabs}
+              classes={{ indicator: classes.indicator }}
+            >
 
-                <Tab label={<>({totalunaffiliatedCount + totalaffiliatedCount })</>} icon="All" {...a11yProps(0)} className={classes.tabVal} />
-                <Tab  icon="Unaffiliated"  label={<>({affiliatedOrganizationsObject["unaffiliated"] ? affiliatedOrganizationsObject["unaffiliated"].length : 0})</>} className={classes.tabVal} {...a11yProps(1)} />
-                <Tab  icon="Affiliated" label={<>({totalaffiliatedCount})</>} className={classes.tabVal} {...a11yProps(2)} />
-              </Tabs>
-            </AppBar>
-          </MuiThemeProvider>
-
-
-
+              <Tab label={<>({totalunaffiliatedCount + totalaffiliatedCount })</>} icon="All" {...a11yProps(0)} classes={{ root: classes.tabRoot, selected: classes.tabSelected }} />
+              <Tab  icon="Unaffiliated"  label={<>({affiliatedOrganizationsObject["unaffiliated"] ? affiliatedOrganizationsObject["unaffiliated"].length : 0})</>} classes={{ root: classes.tabRoot, selected: classes.tabSelected }} {...a11yProps(1)} />
+              <Tab  icon="Affiliated" label={<>({totalaffiliatedCount})</>} classes={{ root: classes.tabRoot, selected: classes.tabSelected }} {...a11yProps(2)} />
+            </Tabs>
+          </AppBar>
           <Grid index={value}>
             <Grid>
               <FormGroup>

--- a/src/pages/Contributors/styles.js
+++ b/src/pages/Contributors/styles.js
@@ -73,7 +73,17 @@ export const useStyle = makeStyles((theme) => ({
     },
 
   },
-
+  tabRoot: {
+    color: "theme​.palette.​text.disabled",
+    fontWeight: 'bold',
+    textTransform: 'none',
+    fontSize: '32px',
+    "&$tabSelected": {
+      color: "#006B95",
+    },
+  },
+  tabSelected: {},
+  
   chkBoxStyle: {
     color: '#6D6E74',
     paddingLeft: '59rem',


### PR DESCRIPTION
Closes #664 , #675 and #668
Issues Addressed :

1.Search results partially expanded.

2.Organizations page: show correct filtered results without an close/expand action of the Code for All dropdown got fixed

3.removed MuiThemeProvider and did Tab styling in style.js