### PR TITLE
Fix 'View contributors' link

### DIFF
--- a/cypress/integration/pages/contributors.spec.js
+++ b/cypress/integration/pages/contributors.spec.js
@@ -1,6 +1,6 @@
 describe('Contributors Page', () => {
   before(() => {
-    cy.visit('/contributors/all')
+    cy.visit('/organizations/all')
   })
 
   it('wait for affiliated orgs to load', () => {

--- a/src/App.js
+++ b/src/App.js
@@ -66,6 +66,7 @@ const App = () => {
             <Redirect from='/how-to' to='/join-index/how-to-add' />
             <Redirect from='/how-to-use' to='/join-index/how-to-add' />
             <Redirect from='/join' to='/join-index' />
+            <Redirect from='/organizations' to='/organizations/all' />
             <Redirect from='/search' to='/projects' />
             <Redirect from='/share' to='/support/share' />
             <Redirect from='/tag-creator' to='/join-index' />

--- a/src/pages/Home/sections/NotableUsersSection.js
+++ b/src/pages/Home/sections/NotableUsersSection.js
@@ -119,7 +119,7 @@ const NotableUsersSection = () => {
     return (
       <Grid item xs={12} style={{ padding: '30px' }}>
         <div align='center'>
-          <NavButton href='/contributors/affiliated' color='primary'>
+          <NavButton href='/organizations/affiliated' color='primary'>
                         View contributors
           </NavButton>
         </div>


### PR DESCRIPTION
Closes #736 

Updates old `/contributors...` links to new `/organizations...` links
Redirects so that `/organizations` doesn't 404  