### PR TITLE
Clean src/styles.js to remove ESLint warning

### DIFF
--- a/src/styles.js
+++ b/src/styles.js
@@ -81,11 +81,11 @@ const useStyles = makeStyles((theme) => ({
     '.boxBackground': {
       backgroundColor: theme.palette.background.primary,
     },
-    '.indv-header-bg':{
+    '.indv-header-bg': {
       backgroundImage: 'url(/images/indv-org-page-bg.png)',
       minHeight: '512px',
       maxHeight: '580px',
-    }
+    },
   },
 }));
 


### PR DESCRIPTION
A small PR for code quality; does not close a specific issue.

Clean `src/styles.js` to remove ESLint warning. Ran Prettier.

Before:
```
  88:6  warning  Missing trailing comma  comma-dangle
```
After:
  (no warnings, no errors)