### PR TITLE
Clean IndvOrganization/index.js to remove 1 ESLint warning

### DIFF
--- a/src/pages/IndvOrganization/index.js
+++ b/src/pages/IndvOrganization/index.js
@@ -111,7 +111,7 @@ const IndvOrgPage = ({ match }) => {
               for (let j=po.length-1; j>=0; --j){
                 parentOrgs.push(po[j].name);
               }
-             
+
               setCrumbs(crumbs);
               setParentOrgs(parentOrgs)
               setCrumbsInSmallScreen(crumbsInSmallScreen);


### PR DESCRIPTION
A small PR for code quality; does not close a specific issue.

Clean `IndvOrganization/index.js` to remove 1 ESLint warning

Before:
```
  114:1  warning  Trailing spaces not allowed  no-trailing-spaces
```

After:
  no warnings