### PR TITLE
Add eslint-disable to resolve 1 ESLint warning in FilterSelector.js

### DIFF
--- a/src/pages/SearchProjects/FilterSelector.js
+++ b/src/pages/SearchProjects/FilterSelector.js
@@ -1,3 +1,4 @@
+/* eslint-disable multiline-comment-style */
 import React, { useState } from 'react';
 import { ThemeProvider, makeStyles } from '@material-ui/core/styles';
 import Box from '@material-ui/core/Box';


### PR DESCRIPTION
A small PR for code quality; does not close a specific issue.

Add `eslint-disable` to resolve 1 ESLint warning in `FilterSelector.js`. This keeps the comments as they are, waiting for when we can add in a `LastUpdated` filter.

Before:
```
  310:5  warning  Expected a block comment instead of consecutive line comments  multiline-comment-style
```

After:
  no warnings, no errors