### PR TITLE
Clean up ProjectCard.js to remove 2 ESLint warnings

### DIFF
--- a/src/components/ProjectCard.js
+++ b/src/components/ProjectCard.js
@@ -1,29 +1,28 @@
 import React from 'react';
+import { makeStyles } from '@material-ui/styles';
+import Avatar from '@material-ui/core/Avatar';
 import Card from '@material-ui/core/Card';
 import CardContent from '@material-ui/core/CardContent';
 import Chip from '@material-ui/core/Chip';
 import Grid from '@material-ui/core/Grid';
 import FiberManualRecordRoundedIcon from '@material-ui/icons/FiberManualRecordRounded';
 import githubColorDictionary from './data/gh-colors.json';
-import Avatar from '@material-ui/core/Avatar';
-import { makeStyles } from '@material-ui/styles';
 
 const useStyles = makeStyles((theme) => ({
-
   select : {
     [theme.breakpoints.down('xs')]: {
       width: '55vw',
     },
   },
   chipStyle : {
-    backgroundColor: '#F1F1F1', 
+    backgroundColor: '#F1F1F1',
     paddingLeft: '2px',
   },
   issueStyles : {
     fontSize: '13px',
     fontStyle: 'normal',
     fontWeight: '400',
-  }
+  },
 }));
 
 const renderLanguageChip = (language,classes) => {


### PR DESCRIPTION
A small PR for code quality; does not close a specific issue.

Before:
```
  19:32  warning  Trailing spaces not allowed  no-trailing-spaces
  26:4   warning  Missing trailing comma       comma-dangle
```

After:
  (no warnings, no errors)