### PR TITLE
Revert Link to the organization page

### DIFF
--- a/src/components/ContributorThumbnail.js
+++ b/src/components/ContributorThumbnail.js
@@ -192,7 +192,7 @@ const Thumbnail = ({
             }
           >
             <Link
-              href={thumbnailInfo.organizationUrl}
+              href={`/organization/${organization.slug}`}
               target='_blank'
               rel='noreferrer noopener'
             >


### PR DESCRIPTION
Revert change to Link in `ContributorThumbnail.js` to use the `slug` so it links to the organization project card, not to the external URL of the org.

Here is a screenshot showing how the change crept in as part of #749 
<img width="703" alt="Screen Shot 2021-08-05 at 6 41 57 PM" src="https://user-images.githubusercontent.com/1218844/128443127-7d6dbc6f-7767-4344-8930-6e89752dde49.png">

Please review carefully! This is not fully tested, just a quick PR to attempt to get the link back to what it was.
