### PR TITLE
Add 'spectrum' to palette as another way to use colors

### DIFF
--- a/src/guides/colors.js
+++ b/src/guides/colors.js
@@ -60,16 +60,22 @@ const ShowColors = () => {
         <Grid item xs={6} md={3}>
           <Card className='card242'>
             <CardContent>
-              <ColorBox color={theme.palette.primary.main} />
+              <ColorBox color={theme.palette.spectrum.darkBlue} />
               <Typography variant='h6' className={classes.colorName}>
                 Dark Blue
               </Typography>
               <Typography variant='body2' color='secondary'>
                 Color: #0F1D2F
               </Typography>
-              <Typography variant='body1'>Primary text color throughout site. Also used as footer background.</Typography>
+              <Typography variant='body1'>
+                Primary text color throughout site. Also used as footer
+                background.
+              </Typography>
             </CardContent>
             <CardFooter>
+              <Typography variant='body1' className={classes.mono}>
+                theme&#8203;.palette.&#8203;spectrum.darkBlue
+              </Typography>
               <Typography variant='body1' className={classes.mono}>
                 theme&#8203;.palette.&#8203;primary.main
               </Typography>
@@ -88,16 +94,22 @@ const ShowColors = () => {
         <Grid item xs={6} md={3}>
           <Card className='card242'>
             <CardContent>
-              <ColorBox color={theme.palette.secondary.dark} />
+              <ColorBox color={theme.palette.spectrum.teal} />
               <Typography variant='h6' className={classes.colorName}>
                 Teal
               </Typography>
               <Typography variant='body2' color='secondary'>
                 Color: #004364
               </Typography>
-              <Typography variant='body1'>Primary background color. Also used as heading color on light backgrounds.</Typography>
+              <Typography variant='body1'>
+                Primary background color. Also used as heading color on light
+                backgrounds.
+              </Typography>
             </CardContent>
             <CardFooter>
+              <Typography variant='body1' className={classes.mono}>
+                theme&#8203;.palette.&#8203;spectrum.teal
+              </Typography>
               <Typography variant='body1' className={classes.mono}>
                 theme.&#8203;palette.&#8203;secondary.dark
               </Typography>
@@ -110,16 +122,21 @@ const ShowColors = () => {
         <Grid item xs={6} md={3}>
           <Card className='card242'>
             <CardContent>
-              <ColorBox color={theme.palette.secondary.main} />
+              <ColorBox color={theme.palette.spectrum.lightBlue} />
               <Typography variant='h6' className={classes.colorName}>
                 Light Blue
               </Typography>
               <Typography variant='body2' color='secondary'>
                 Color: #0D99C6
               </Typography>
-              <Typography variant='body1'>Used for standard hyperlinks and primary buttons.</Typography>
+              <Typography variant='body1'>
+                Used for standard hyperlinks and primary buttons.
+              </Typography>
             </CardContent>
             <CardFooter>
+              <Typography variant='body1' className={classes.mono}>
+                theme&#8203;.palette.&#8203;spectrum.lightBlue
+              </Typography>
               <Typography variant='body1' className={classes.mono}>
                 theme&#8203;.palette.&#8203;secondary.main
               </Typography>
@@ -132,16 +149,22 @@ const ShowColors = () => {
         <Grid item xs={6} md={3}>
           <Card className='card242'>
             <CardContent>
-              <ColorBox color={theme.palette.secondary.light} />
+              <ColorBox color={theme.palette.spectrum.lightBlueVariant} />
               <Typography variant='h6' className={classes.colorName}>
                 Light Blue - Variant
               </Typography>
               <Typography variant='body2' color='secondary'>
                 Color: #5FCAF9
               </Typography>
-              <Typography variant='body1'>Used for hyperlinks and icons on dark backgrounds and the footer.</Typography>
+              <Typography variant='body1'>
+                Used for hyperlinks and icons on dark backgrounds and the
+                footer.
+              </Typography>
             </CardContent>
             <CardFooter>
+              <Typography variant='body1' className={classes.mono}>
+                theme&#8203;.palette.&#8203;spectrum.lightBlueVariant
+              </Typography>
               <Typography variant='body1' className={classes.mono}>
                 theme&#8203;.palette.&#8203;secondary.light
               </Typography>
@@ -154,16 +177,21 @@ const ShowColors = () => {
         <Grid item xs={6} md={3}>
           <Card className='card242'>
             <CardContent>
-              <ColorBox color={theme.palette.warning.main} />
+              <ColorBox color={theme.palette.spectrum.yellow} />
               <Typography variant='h6' className={classes.colorName}>
                 Yellow
               </Typography>
               <Typography variant='body2' color='secondary'>
                 Color: #FFE06D
               </Typography>
-              <Typography variant='body1'>Used only for headers on primary backgrounds.</Typography>
+              <Typography variant='body1'>
+                Used only for headers on primary backgrounds.
+              </Typography>
             </CardContent>
             <CardFooter>
+              <Typography variant='body1' className={classes.mono}>
+                theme&#8203;.palette.&#8203;spectrum.yellow
+              </Typography>
               <Typography variant='body1' className={classes.mono}>
                 theme&#8203;.palette.&#8203;warning.main
               </Typography>
@@ -179,16 +207,23 @@ const ShowColors = () => {
         <Grid item xs={6} md={3}>
           <Card className='card242'>
             <CardContent>
-              <ColorBox color={theme.palette.background.default} />
+              <ColorBox color={theme.palette.spectrum.white} />
               <Typography variant='h6' className={classes.colorName}>
                 White
               </Typography>
               <Typography variant='body2' color='secondary'>
                 Color: #FEFEFE
               </Typography>
-              <Typography variant='body1'>Used only for headers on primary backgrounds.</Typography>
+              <Typography variant='body1'>
+                Background color for cards, containers and field forms.
+                Additionally used for text on dark backgrounds and button
+                labels.
+              </Typography>
             </CardContent>
             <CardFooter>
+              <Typography variant='body1' className={classes.mono}>
+                theme&#8203;.palette.&#8203;spectrum.white
+              </Typography>
               <Typography variant='body1' className={classes.mono}>
                 theme&#8203;.palette.&#8203;background.default
               </Typography>
@@ -211,7 +246,7 @@ const ShowColors = () => {
         <Grid item xs={6} md={3}>
           <Card className='card242'>
             <CardContent>
-              <ColorBox color={theme.palette.text.disabled} />
+              <ColorBox color={theme.palette.spectrum.darkGray} />
               <Typography variant='h6' className={classes.colorName}>
                 Dark Gray
               </Typography>
@@ -219,10 +254,14 @@ const ShowColors = () => {
                 Color: #6D6E74
               </Typography>
               <Typography variant='body1'>
-                Stroke color for interactive elements and field forms. Also used for secondary information such as labels and disabled states.
+                Stroke color for interactive elements and field forms. Also used
+                for secondary information such as labels and disabled states.
               </Typography>
             </CardContent>
             <CardFooter>
+              <Typography variant='body1' className={classes.mono}>
+                theme&#8203;.palette.&#8203;spectrum.darkGray
+              </Typography>
               <Typography variant='body1' className={classes.mono}>
                 theme&#8203;.palette.&#8203;text.disabled
               </Typography>
@@ -232,53 +271,87 @@ const ShowColors = () => {
         <Grid item xs={6} md={3}>
           <Card className='card242'>
             <CardContent>
-              <ColorBox color={theme.palette.background.secondary} />
+              <ColorBox color={theme.palette.spectrum.lightGray} />
               <Typography variant='h6' className={classes.colorName}>
                 Light Gray
               </Typography>
               <Typography variant='body2' color='secondary'>
                 Color: #F2F2F2
               </Typography>
-              <Typography variant='body1'>Secondary background color in place of white.</Typography>
+              <Typography variant='body1'>
+                Secondary background color in place of white.
+              </Typography>
             </CardContent>
             <CardFooter>
+              <Typography variant='body1' className={classes.mono}>
+                theme&#8203;.palette.&#8203;spectrum.lightGray
+              </Typography>
               <Typography variant='body1' className={classes.mono}>
                 theme&#8203;.palette.&#8203;background.secondary
               </Typography>
             </CardFooter>
           </Card>
         </Grid>
-        <Grid item xs={0} md={6} />
         <Grid item xs={6} md={3}>
           <Card className='card242'>
             <CardContent>
-              <ColorBox color={theme.palette.secondary.main} />
+              <ColorBox color={theme.palette.spectrum.lightBlueHover} />
               <Typography variant='h6' className={classes.colorName}>
                 Light Blue - Hover
               </Typography>
               <Typography variant='body2' color='secondary'>
                 Color: #006B95
               </Typography>
-              <Typography variant='body1'>Fill color for hovered primary buttons.</Typography>
+              <Typography variant='body1'>
+                Fill color for hovered primary buttons.
+              </Typography>
             </CardContent>
             <CardFooter>
-              <Typography variant='body1'>(n/a)</Typography>
+              <Typography variant='body1' className={classes.mono}>
+                theme&#8203;.palette.&#8203;spectrum.lightBlueHover
+              </Typography>
             </CardFooter>
           </Card>
         </Grid>
         <Grid item xs={6} md={3}>
           <Card className='card242'>
             <CardContent>
-              <ColorBox color={theme.palette.error.main} />
+              <ColorBox color={theme.palette.spectrum.green} />
+              <Typography variant='h6' className={classes.colorName}>
+                Green
+              </Typography>
+              <Typography variant='body2' color='secondary'>
+                Color: #5A9E5F
+              </Typography>
+              <Typography variant='body1'>
+                Icon and accent color for successful states.
+              </Typography>
+            </CardContent>
+            <CardFooter>
+              <Typography variant='body1' className={classes.mono}>
+                theme&#8203;.palette.&#8203;spectrum.green
+              </Typography>
+            </CardFooter>
+          </Card>
+        </Grid>
+        <Grid item xs={6} md={3}>
+          <Card className='card242'>
+            <CardContent>
+              <ColorBox color={theme.palette.spectrum.red} />
               <Typography variant='h6' className={classes.colorName}>
                 Red
               </Typography>
               <Typography variant='body2' color='secondary'>
                 Color: #D20E0E
               </Typography>
-              <Typography variant='body1'>Use for text label errors.</Typography>
+              <Typography variant='body1'>
+                Icon and accent color for unsuccessful or error states.
+              </Typography>
             </CardContent>
             <CardFooter>
+              <Typography variant='body1' className={classes.mono}>
+                theme&#8203;.palette.&#8203;spectrum.red
+              </Typography>
               <Typography variant='body1' className={classes.mono}>
                 theme&#8203;.palette.&#8203;error.main
               </Typography>
@@ -288,17 +361,21 @@ const ShowColors = () => {
         <Grid item xs={6} md={3}>
           <Card className='card242'>
             <CardContent>
-              <ColorBox color='#551A8B' />
+              <ColorBox color={theme.palette.spectrum.purple} />
               <Typography variant='h6' className={classes.colorName}>
                 Purple
               </Typography>
               <Typography variant='body2' color='secondary'>
                 Color: #551A8B
               </Typography>
-              <Typography variant='body1'>Used to denote visited links.</Typography>
+              <Typography variant='body1'>
+                Used to denote visited links.
+              </Typography>
             </CardContent>
             <CardFooter>
-              <Typography variant='body1'>(n/a)</Typography>
+              <Typography variant='body1' className={classes.mono}>
+                theme&#8203;.palette.&#8203;spectrum.purple
+              </Typography>
             </CardFooter>
           </Card>
         </Grid>

--- a/src/theme-mui.js
+++ b/src/theme-mui.js
@@ -1,6 +1,7 @@
 /* eslint-disable sort-keys */
 import createBreakpoints from '@material-ui/core/styles/createBreakpoints';
 import deepmerge from '@material-ui/utils/deepmerge';
+import spectrum from './theme-spectrum';
 
 // Colors - Primary
 const DARK_BLUE = '#0F1D2F';
@@ -295,6 +296,7 @@ const themeSettings = {
     background: {
       default: WHITE,
     },
+    spectrum: { ...spectrum },
   },
   typography: {
     fontFamily: 'Work Sans, sans-serif',

--- a/src/theme-spectrum.js
+++ b/src/theme-spectrum.js
@@ -1,0 +1,20 @@
+// https://www.figma.com/file/EFoSuj1b9G4aZ7bN8OX8tf/CivicTechIndex---Master-Design-File?node-id=11363%3A60670
+
+const spectrum = {
+  // Primary
+  darkBlue: '#0F1D2F',
+  teal: '#004364',
+  lightBlue: '#0D99C6',
+  lightBlueVariant: '#5FCAF9',
+  yellow: '#FFE06D',
+  white: '#FEFEFE',
+  // Secondary
+  darkGray: '#6D6E74',
+  lightGray: '#F2F2F2',
+  lightBlueHover: '#006B95',
+  green: '#5A9E5F',
+  red: '#D20E0E',
+  purple: '#551A8B',
+};
+
+export default spectrum;


### PR DESCRIPTION
Adds `theme-spectrum.js` file as a new alternative way to use our palette of 12 colors.  🎨
Adds a `spectrum` object to the Material-UI theme's `palette`.
Updates the [Colors guide page](http://civictechindex.org/guides/colors) accordingly.

<hr>

Now we have a 12th color, `green`, in our theme palette.

And we can access all 12 CTI colors by using the Material-UI theme with code like `theme.palette.spectrum.darkGray` or `theme.palette.spectrum.lightBlueVariant`. This type of notation can be used for all 12 colors. Previously, not all colors were accessible this way.

(Also, if there happens to be a good reason for doing so, the `spectrum` file could be `import`ed to use these colors in a way that does not require the Material-UI theme.)

All of this goodness comes with this PR, and it does not have any impact on any existing color usage. ✨