### PR TITLE
Center content of Tag Generator page

### DIFF
--- a/src/pages/TagCreator/index.js
+++ b/src/pages/TagCreator/index.js
@@ -23,9 +23,11 @@ import Instructions from './Instructions'
 import { makeStyles } from '@material-ui/core/styles'
 const useStyles = makeStyles((theme) => ({
   containerPadding: {
-    paddingLeft:'100px',
+    paddingLeft: 100,
+    paddingRight: 100,
     [theme.breakpoints.down('sm')]: {
-      paddingLeft:'40px',
+      paddingLeft:40,
+      paddingRight:40,
     },
     [theme.breakpoints.down('xs')]: {
       padding:'0px 16px',

--- a/src/pages/TagCreator/index.js
+++ b/src/pages/TagCreator/index.js
@@ -26,11 +26,11 @@ const useStyles = makeStyles((theme) => ({
     paddingLeft: 100,
     paddingRight: 100,
     [theme.breakpoints.down('sm')]: {
-      paddingLeft:40,
-      paddingRight:40,
+      paddingLeft: 40,
+      paddingRight: 40,
     },
     [theme.breakpoints.down('xs')]: {
-      padding:'0px 16px',
+      padding: '0px 16px',
     },
   },
 }))


### PR DESCRIPTION
Closes #794  

Centers content of Tag Generator. Makes container's padding left and right equal.