### PR TITLE
Refactor FAQ spec

### DIFF
--- a/cypress/fixtures/faqs.json
+++ b/cypress/fixtures/faqs.json
@@ -1,0 +1,64 @@
+{
+  "results": [
+    {
+      "id": 15,
+      "question": "Can I add multiple projects?",
+      "answer": "Yes, Please follow the <a href=\"http://civictechindex.org/join-index?tagsToAdd=civictechindex\">link</a> to add multiple projects.",
+      "view_count": 268
+    },
+    {
+      "id": 19,
+      "question": "Our organization doesn't have a parent organization. What should I do?",
+      "answer": "You can still be a part of Civic tech index, even if your organization is <a href=\"http://civictechindex.org/organizations/all\">unaffiliated</a>",
+      "view_count": 258
+    },
+    {
+      "id": 5,
+      "question": "What is Civic Tech Index?",
+      "answer": "<a href=\"http://civictechindex.org/home\">Civic Tech Index</a> is a comprehensive, searchable index of all civic tech open-source software projects around the world. It helps to create large-scale engagement, overlapping technologies, and disciplines. People of all different skills and levels working to problem solve, projects that are legitimate and trustworthy.",
+      "view_count": 57
+    },
+    {
+      "id": 11,
+      "question": "How do I add my organization to Civic Tech Index?",
+      "answer": "To add an organization to Civic Tech Index, please click on this <a href=\"http://civictechindex.org/join-index?tagsToAdd=civictechindex\">link</a>.",
+      "view_count": 20
+    },
+    {
+      "id": 17,
+      "question": "What if I can't find my project's repository link on GitHub?",
+      "answer": "Occasionally, some projects are not listed. Please type the URL manually and submit the project repository <a href=\"http://civictechindex.org/join-index?tagsToAdd=civictechindex\">link</a>.",
+      "view_count": 9
+    },
+    {
+      "id": 9,
+      "question": "What is the difference between affiliated and unaffiliated contributors?",
+      "answer": "\"If the organization isn't affiliated with a larger umbrella organization like Code for All or Democracy Lab and is an independent entity, it is unaffiliated, otherwise it's affiliated (with a sponsoring organization).",
+      "view_count": 9
+    },
+    {
+      "id": 22,
+      "question": "How do I add tags to my project's repository?",
+      "answer": "To add your tags to your project’s repository. Follow the <a href=\"http://civictechindex.org/join-index?tagsToAdd=civictechindex\">link</a>.",
+      "view_count": 8
+    },
+    {
+      "id": 23,
+      "question": "What if I want to add additional tags?",
+      "answer": "Yes, you can add more tags to your project's repository using the <a href=\"http://civictechindex.org/join-index?tagsToAdd=civictechindex\">link</a>.",
+      "view_count": 7
+    },
+    {
+      "id": 4,
+      "question": "What is Civic Tech?",
+      "answer": "Civic technology, or civic tech, enhances the relationship between the people and government with software for communications, decision-making, service delivery, and political process. It includes information and communications technology supporting the government with software built by community-led teams of volunteers, nonprofits, consultants, private companies, and embedded tech teams working within the government.",
+      "view_count": 7
+    },
+    {
+      "id": 14,
+      "question": "What is the tag generator?",
+      "answer": "Tag generator is the Civic Tech Index's step-by-step tool for creating topic tags. Topic tags will help improve the discoverability of your projects, and using tags can lead to more traffic to your website from people interested in that topic.",
+      "view_count": 7
+    }
+  ]
+}

--- a/cypress/integration/pages/faq.spec.js
+++ b/cypress/integration/pages/faq.spec.js
@@ -1,15 +1,32 @@
-describe('FAQ Page', () => {
-  const SEARCH = 'organization';
-  const Q1 = 'Can I add multiple projects';
-  const Q2 = "Our organization doesn't have a parent organization";
-  const A1 = 'Yes, Please follow the link to add multiple projects.';
-  const A2 =
-    'You can still be a part of Civic tech index, even if your organization is unaffiliated';
+const SEARCH = 'organization';
+const Q1 = 'Can I add multiple projects';
+const Q2 = "Our organization doesn't have a parent organization";
+const A1 = 'Yes, Please follow the link to add multiple projects.';
+const A2 =
+  'You can still be a part of Civic tech index, even if your organization is unaffiliated';
 
-  before(() => {
-    cy.intercept(`${Cypress.env('REACT_APP_API_URL')}/api/faqs/`).as('getFaqs');
+describe('FAQ Page (using API)', () => {
+  it('gets faq by search', () => {
     cy.visit('/about/faq');
+    cy.get('[data-cy=search-faq]').click({ force: true }).type(SEARCH);
+    cy.intercept(`${Cypress.env('REACT_APP_API_URL')}/api/faqs/*`).as(
+      'getFaqs'
+    );
     cy.wait('@getFaqs');
+    cy.get('[data-cy=faq-question]')
+      .first()
+      .contains(Q2)
+      .click({ force: true });
+    cy.get('[data-cy=faq-answer]').first().should('have.text', A2);
+  });
+});
+
+describe('FAQ Page (using fixture)', () => {
+  before(() => {
+    cy.intercept(`${Cypress.env('REACT_APP_API_URL')}/api/faqs/`, {
+      fixture: 'faqs.json',
+    });
+    cy.visit('/about/faq');
   });
 
   it('title section loads', () => {
@@ -17,22 +34,11 @@ describe('FAQ Page', () => {
   });
 
   it('default faq list is loaded', () => {
+    cy.get('[data-cy=faq-question]').should('have.length', 10);
     cy.get('[data-cy=faq-question]')
       .first()
       .contains(Q1)
       .click({ force: true });
     cy.get('[data-cy=faq-answer]').first().should('have.text', A1);
-  });
-
-  it('gets faq by search', () => {
-    cy.get('[data-cy=search-faq]').click({ force: true }); // need two get's to avoid flaky test
-    cy.get('[data-cy=search-faq]').click({ force: true }).type(SEARCH);
-    cy.intercept(`${Cypress.env('REACT_APP_API_URL')}/api/faqs/`).as('getFaqs');
-    cy.wait('@getFaqs');
-    cy.get('[data-cy=faq-question]')
-      .first()
-      .contains(Q2)
-      .click({ force: true });
-    cy.get('[data-cy=faq-answer]').first().should('have.text', A2);
   });
 });


### PR DESCRIPTION
This PR refactors `faq.spec.js` just a little bit:

- Adjust the API call, to (hopefully) avoid failures. Note the addition of an asterisk to the `cy.intercept` URL.
- Adds a fixture (`faqs.json`) for using in some of the tests instead of downloading from the API. (This is a pattern we can continue to use — some end-to-end tests that use the API , along with some tests that use a fixture for speed.)

Motivation:
The FAQ Cypress test is failing sometimes. (Flake.) Here is a screenshot of a recent error:
![Screen Shot 2021-08-22 at 4 09 39 PM](https://user-images.githubusercontent.com/1218844/130373152-30dd2121-93e2-4c15-baa5-9980883bf998.png)
