### PR TITLE
Display correct url in add tag instructions (#824)

### DIFF
--- a/src/pages/TagCreator/index.js
+++ b/src/pages/TagCreator/index.js
@@ -409,7 +409,7 @@ const TagCreator = () => {
             setDisplayState={setDisplayState}
             userTags={userTags}
             repositoryName={repositoryName}
-            repositoryUrl={repositoryUrl}
+            repositoryUrl={'https://github.com/' + getRepositoryUrlPath(repositoryUrl)}
             linkStyles={linkStyles}
           />
         </>


### PR DESCRIPTION
Closes #824 

* Send full github url to CopyPasteTags