### PR TITLE
Added link to Medium from Share the CTI Page

### DIFF
--- a/src/pages/RadicalCollaboration/Share/index.js
+++ b/src/pages/RadicalCollaboration/Share/index.js
@@ -3,6 +3,7 @@ import Box from '@material-ui/core/Box';
 import Button from '@material-ui/core/Button';
 import Container from '@material-ui/core/Container';
 import Card from '@material-ui/core/Card';
+import CardActionArea from '@material-ui/core/CardActionArea';
 import CardActions from '@material-ui/core/CardActions';
 import CardContent from '@material-ui/core/CardContent';
 import CardMedia from '@material-ui/core/CardMedia';
@@ -93,14 +94,16 @@ const useStyles = makeStyles((theme) => ({
 const StarMediaSection = () => {
   const classes = useStyles();
 
-  const CardSection = ({ image, title, cardContent }) => {
+  const CardSection = ({ image, title, cardContent, link='' }) => {
     return (
-      <Card className={classes.card}>
-        <CardMedia className={classes.media} image={image} title={title} />
-        <CardContent>
-          <Typography variant='h6' className={classes.cardTypo}>{cardContent}</Typography>
-        </CardContent>
-      </Card>
+      <CardActionArea href={link}>
+        <Card className={classes.card}>
+          <CardMedia className={classes.media} image={image} title={title} />
+          <CardContent>
+            <Typography variant='h6' className={classes.cardTypo}>{cardContent}</Typography>
+          </CardContent>
+        </Card>
+      </CardActionArea>
     );
   };
   return (
@@ -130,6 +133,7 @@ const StarMediaSection = () => {
           image='/images/medium.png'
           title='Medium logo'
           cardContent='Mention or write about us on Medium'
+          link='https://medium.com/new-story'
         />
       </Grid>
       <Grid item sm={4}>


### PR DESCRIPTION
Closes #835 

This pull request adds a link to Medium to the Medium icon on the Share the CTI Page.

## Testing
**Link to Share the CTI Page**: http://localhost:3000/support/share

To verify that this feature is working, click on the card with the Medium icon on it and ensure it redirects to https://medium.com/new-story

*Note*: The link may lead to https://medium.com/m/signin. This is normal if you aren't signed into Medium at the time.