### PR TITLE
Background of ViewOrganization

### DIFF
--- a/src/pages/IndvOrganization/Header.js
+++ b/src/pages/IndvOrganization/Header.js
@@ -11,9 +11,12 @@ const DARK_BLUE = '#0F1D2F';
 const useStyles = makeStyles((theme) => ({
   indvOrgBackgroundImgStyle: {
     backgroundImage: 'url(/images/indv-org-page-bg.png)',
+    backgroundSize: 'contain',
     minHeight: '580px',
     [theme.breakpoints.down('md')]: {
       minHeight: '512px',
+      backgroundSize: 'cover',
+      backgroundRepeat: 'no-repeat',
     },
   },
   logImgStyle: {


### PR DESCRIPTION
indvOrgBackgroundImageStyle to 'contain' image in larger display sizes when minHeight = 580, and 'cover' in smaller displays when minHeight = 512.
Closes #1112 