### PR TITLE
ARIA labels and titles for accessibility

### DIFF
--- a/src/components/Footer/DropdownList.js
+++ b/src/components/Footer/DropdownList.js
@@ -16,25 +16,43 @@ const DropdownList = ({ header, links, route }) => {
 
   return (
     <>
-      <Box className={classes.dropdownHeader} onClick={links.length ? toggleList : null}>
+      <Box
+        className={classes.dropdownHeader}
+        onClick={links.length ? toggleList : null}
+      >
         <Typography
           variant='body2'
           color='textSecondary'
           component={Link}
           to={route}
-        >{header}
+        >
+          {header}
         </Typography>
-        {links.length > 0 && (open ? <ExpandLessRounded /> : <ExpandMoreRounded />)}
+        {links.length > 0 &&
+          (open ? <ExpandLessRounded /> : <ExpandMoreRounded />)}
       </Box>
       {open &&
         links.map((link) => {
           return link.isExternal ? (
-            <a key={link.id} href={link.route}>{link.header}</a>
+            <a
+              aria-label={link.label}
+              key={link.id}
+              href={link.route}
+              title={link.tooltip}
+            >
+              {link.header}
+            </a>
           ) : (
-            <Link key={link.id} to={link.route}>{link.header}</Link>
+            <Link
+              aria-label={link.label}
+              key={link.id}
+              to={link.route}
+              title={link.tooltip}
+            >
+              {link.header}
+            </Link>
           );
-        })
-      }
+        })}
     </>
   );
 };

--- a/src/components/Footer/LinkList.js
+++ b/src/components/Footer/LinkList.js
@@ -20,11 +20,11 @@ const LinkList = ({ header, links, route }) => {
       </Typography>
       {links.map((link) => {
         return link.isExternal ? (
-          <a key={link.id} href={link.route}>
+          <a aria-label={link.label} key={link.id} href={link.route} title={link.tooltip}>
             {link.header}
           </a>
         ) : (
-          <Link key={link.id} to={link.route}>
+          <Link aria-label={link.label} key={link.id} to={link.route} title={link.tooltip}>
             {link.header}
           </Link>
         );

--- a/src/components/Footer/LinkList.js
+++ b/src/components/Footer/LinkList.js
@@ -20,11 +20,21 @@ const LinkList = ({ header, links, route }) => {
       </Typography>
       {links.map((link) => {
         return link.isExternal ? (
-          <a aria-label={link.label} key={link.id} href={link.route} title={link.tooltip}>
+          <a
+            aria-label={link.label}
+            key={link.id}
+            href={link.route}
+            title={link.tooltip}
+          >
             {link.header}
           </a>
         ) : (
-          <Link aria-label={link.label} key={link.id} to={link.route} title={link.tooltip}>
+          <Link
+            aria-label={link.label}
+            key={link.id}
+            to={link.route}
+            title={link.tooltip}
+          >
             {link.header}
           </Link>
         );

--- a/src/components/Header/DropdownList.js
+++ b/src/components/Header/DropdownList.js
@@ -26,10 +26,11 @@ const DropdownList = ({ linkClickHandler, header, links, route }) => {
     const { header, isExternal, route } = link;
     if (isExternal) {
       return (
-        <a 
-          aria-label={link.label} 
-          href={route} onClick={handleClick} 
-          style={{ textDecoration: 'none' }} 
+        <a
+          aria-label={link.label}
+          href={route}
+          onClick={handleClick}
+          style={{ textDecoration: 'none' }}
           title={link.tooltip}
         >
           {header}
@@ -57,11 +58,19 @@ const DropdownList = ({ linkClickHandler, header, links, route }) => {
           // component={Link} to={route} // uncomment to create Menu header as link
           variant='body2'
           color='textSecondary'
-          style={{ cursor: 'pointer', fontWeight: 'bold', textDecoration: 'none' }}
+          style={{
+            cursor: 'pointer',
+            fontWeight: 'bold',
+            textDecoration: 'none',
+          }}
         >
           {header}
         </Typography>
-        {open ? <ExpandLessRounded color='secondary' /> : <ExpandMoreRounded color='primary' />}
+        {open ? (
+          <ExpandLessRounded color='secondary' />
+        ) : (
+          <ExpandMoreRounded color='primary' />
+        )}
       </Box>
       <Collapse in={open} className={classes.collapse}>
         <List dense disablePadding>

--- a/src/components/Header/DropdownList.js
+++ b/src/components/Header/DropdownList.js
@@ -26,13 +26,24 @@ const DropdownList = ({ linkClickHandler, header, links, route }) => {
     const { header, isExternal, route } = link;
     if (isExternal) {
       return (
-        <a style={{ textDecoration: 'none' }} href={route} onClick={handleClick}>
+        <a 
+          aria-label={link.label} 
+          href={route} onClick={handleClick} 
+          style={{ textDecoration: 'none' }} 
+          title={link.tooltip}
+        >
           {header}
         </a>
       );
     } else {
       return (
-        <Link style={{ textDecoration: 'none' }} to={route} onClick={handleClick}>
+        <Link
+          aria-label={link.label}
+          style={{ textDecoration: 'none' }}
+          title={link.tooltip}
+          to={route}
+          onClick={handleClick}
+        >
           {header}
         </Link>
       );

--- a/src/components/Header/HeaderLarge.js
+++ b/src/components/Header/HeaderLarge.js
@@ -22,10 +22,12 @@ const HeaderLarge = () => {
               {nav.subNavigation.map((subNav) => {
                 return (
                   <NavSublink
-                    key={subNav.id}
+                    label={subNav.label}
                     header={subNav.header}
-                    route={subNav.route}
                     isExternal={subNav.isExternal}
+                    key={subNav.id}
+                    route={subNav.route}
+                    title={subNav.tooltip}
                   />
                 );
               })}

--- a/src/components/Header/HeaderLarge.js
+++ b/src/components/Header/HeaderLarge.js
@@ -13,12 +13,21 @@ const HeaderLarge = () => {
   return (
     <nav className={classes.nav}>
       <Link to='/home'>
-        <img className={classes.logo} src='/images/cti-logo.svg' alt='civic logo' />
+        <img
+          className={classes.logo}
+          src='/images/cti-logo.svg'
+          alt='civic logo'
+        />
       </Link>
       <div className={classes.flexContainer}>
         {navigation.map((nav) => {
           return (
-            <NavLink key={nav.id} id={nav.id} header={nav.header} route={nav.route}>
+            <NavLink
+              key={nav.id}
+              id={nav.id}
+              header={nav.header}
+              route={nav.route}
+            >
               {nav.subNavigation.map((subNav) => {
                 return (
                   <NavSublink

--- a/src/components/Header/NavLink.js
+++ b/src/components/Header/NavLink.js
@@ -1,9 +1,13 @@
-import React, { useState, useEffect  } from "react";
+import React, { useState, useEffect } from 'react';
 import { NavLink as NaviLink, withRouter, useLocation } from 'react-router-dom';
 import Link from '@material-ui/core/Link';
 import Menu from 'material-ui-popup-state/HoverMenu';
 import { makeStyles } from '@material-ui/core/styles';
-import { usePopupState, bindMenu, bindHover } from 'material-ui-popup-state/hooks';
+import {
+  usePopupState,
+  bindMenu,
+  bindHover,
+} from 'material-ui-popup-state/hooks';
 import { navigation } from '../../navigation';
 
 const useStyles = makeStyles({
@@ -21,7 +25,6 @@ const useStyles = makeStyles({
   },
 });
 
-
 const NavLink = ({ label, id, children, header, route, title }) => {
   const classes = useStyles();
   const location = useLocation();
@@ -37,7 +40,7 @@ const NavLink = ({ label, id, children, header, route, title }) => {
         break;
       }
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [location.pathname]);
 
   return (

--- a/src/components/Header/NavLink.js
+++ b/src/components/Header/NavLink.js
@@ -22,7 +22,7 @@ const useStyles = makeStyles({
 });
 
 
-const NavLink = ({ id, children, header, route }) => {
+const NavLink = ({ label, id, children, header, route, title }) => {
   const classes = useStyles();
   const location = useLocation();
   const popupState = usePopupState({ variant: 'popper', popupId: 'navlink' });

--- a/src/components/Header/NavSublink.js
+++ b/src/components/Header/NavSublink.js
@@ -14,7 +14,14 @@ const styles = (theme) => ({
   },
 });
 
-const NavSublink = ({ classes, header, isExternal = false, label, route, title }) => {
+const NavSublink = ({
+  classes,
+  header,
+  isExternal = false,
+  label,
+  route,
+  title,
+}) => {
   return (
     <>
       {isExternal ? (

--- a/src/components/Header/NavSublink.js
+++ b/src/components/Header/NavSublink.js
@@ -14,27 +14,31 @@ const styles = (theme) => ({
   },
 });
 
-const NavSublink = ({ classes, header, isExternal = false, route }) => {
+const NavSublink = ({ classes, header, isExternal = false, label, route, title }) => {
   return (
     <>
       {isExternal ? (
         <MenuItem
+          aria-label={label}
           className={classes.menuitem}
           component='a'
           data-cy='menuItem'
           disableGutters
           disableRipple
           href={route}
+          title={title}
         >
           {header}
         </MenuItem>
       ) : (
         <MenuItem
+          aria-label={label}
           className={classes.menuitem}
           component={RouterLink}
           data-cy='menuItem'
           disableGutters
           disableRipple
+          title={title}
           to={route}
         >
           {header}

--- a/src/components/NavButton.js
+++ b/src/components/NavButton.js
@@ -10,14 +10,14 @@ import Button from '@material-ui/core/Button';
  * @param {*} props.variant - optional - contained or outlined
  */
 
-export default function NavButton({ children, href, isExternal,...rest }) {
+export default function NavButton({ children, href, isExternal, label, title, ...rest }) {
 
   return isExternal ? (
-    <Button href={href} {...rest} target='_blank'>
+    <Button aria-label={label} href={href} title={title} {...rest} target='_blank'>
       {children}
     </Button>
   ) : (
-    <Button component={Link} to={href} {...rest}>
+    <Button aria-label={label} component={Link} title={title} to={href} {...rest}>
       {children}
     </Button>
   );

--- a/src/navigation.js
+++ b/src/navigation.js
@@ -88,7 +88,9 @@ const navigation = [
       {
         id: 'volunteer',
         header: 'Volunteer with Us',
+        label: 'Get specific details on the Civic Tech Index project.',
         route: 'https://www.hackforla.org/projects/civic-tech-index',
+        tooltip: 'Get specific details on the Civic Tech Index project.',
         isExternal: true,
       },
     ],

--- a/src/navigation.js
+++ b/src/navigation.js
@@ -88,9 +88,9 @@ const navigation = [
       {
         id: 'volunteer',
         header: 'Volunteer with Us',
-        label: 'Get specific details on the Civic Tech Index project.',
+        label: 'Get specific details on the Civic Tech Index project',
         route: 'https://www.hackforla.org/projects/civic-tech-index',
-        tooltip: 'Get specific details on the Civic Tech Index project.',
+        tooltip: 'Get specific details on the Civic Tech Index project',
         isExternal: true,
       },
     ],

--- a/src/navigation.js
+++ b/src/navigation.js
@@ -100,7 +100,9 @@ const navigation = [
 const findSubNavParent = (subNavRoute) => {
   let results;
   navigation.forEach((nav) => {
-    const found = nav.subNavigation.some((element) => element.route === subNavRoute);
+    const found = nav.subNavigation.some(
+      (element) => element.route === subNavRoute
+    );
     if (found) {
       results = nav.route;
     }

--- a/src/pages/Collaborate/LeftTextRightImage.js
+++ b/src/pages/Collaborate/LeftTextRightImage.js
@@ -90,6 +90,8 @@ const LeftTextRightImage = ({
   mainHeading,
   subHeading,
   description,
+  label,
+  title,
   buttonText,
   buttonHref,
   imageSrc,
@@ -115,9 +117,11 @@ const LeftTextRightImage = ({
           {description}
         </Typography>
         <NavButton
+          aria-label={label}
           href={buttonHref}
           isExternal={hasExternalNav}
           className={classes.leftButtonStyle}
+          title={title}
         >
           {buttonText}
         </NavButton>

--- a/src/pages/Collaborate/index.js
+++ b/src/pages/Collaborate/index.js
@@ -54,14 +54,18 @@ const Collaborate = () => {
               buttonText='Share the Civic Tech Index'
             />
             <LeftTextRightImage
+              label='Read instructions on how to join Hack for LA'
               mainHeading='Volunteer With Us'
               subHeading='Help us improve the Civic Tech Index.'
+              title='Read instructions on how to join Hack for LA'
               description={[
                 'If you would like to volunteer for our organization please visit this ',
                 <Link
+                  aria-label='Read instructions on how to join Hack for LA'
                   key='join'
-                  to='https://www.hackforla.org/join'
                   target='_blank'
+                  title='Read instructions on how to join Hack for LA'
+                  to='https://www.hackforla.org/join'
                 >
                   page.
                 </Link>,


### PR DESCRIPTION
Closes #1107

Adds aria-label and title attributes to links that have the same text but point to different destinations. Only the 'Volunteer with Us' text was found to be applicable in this scenario.

## Testing
* Ensure any 2 links with the same text but different destinations display either a unique tooltip or aria-label attribute

http://localhost:3000/home
* Hover over 'Radical Collaboration' in the header, hover over 'Volunteer with Us' and ensure a tooltip appears with text 'Get specific details on the Civic Tech Index project' for large and small views.
* Hover over 'Volunteer with Us' link in the footer under Radical Collaboration and ensure a tooltip appears with text 'Get specific details on the Civic Tech Index project' for large and small views.

http://localhost:3000/support/collaborate
* Hover over the 'page' external link under the Volunteer with Us section on the page and ensure a tooltip appears with text 'Read instructions on how to join Hack for LA' for large and small views.
* Hover over the 'Become a Volunteer' button and ensure a tooltip appears with text 'Read instructions on how to join Hack for LA' for large and small views.

## For UI/UX
I wanted to get some input from the UI/UX team as the label texts were generated independently without feedback from others, and I figured this issue fell into the category of UI/UX.
### Tooltip text on linking to the Civic Tech Index project page
- 'Get specific details on the Civic Tech Index project'
### Tooltip text on linking to the Join Us page on hackforla.org
- 'Read instructions on how to join Hack for LA'