### PR TITLE
Image alts on collaborate page

### DIFF
--- a/src/pages/Collaborate/LeftTextRightImage.js
+++ b/src/pages/Collaborate/LeftTextRightImage.js
@@ -126,6 +126,7 @@ const LeftTextRightImage = ({
         <CardMedia
           className={classes.leftCardMedia}
           component='img'
+          alt=''
           image={imageSrc}
         />
       </Card>

--- a/src/pages/Collaborate/RightTextLeftImage.js
+++ b/src/pages/Collaborate/RightTextLeftImage.js
@@ -96,6 +96,7 @@ const RightImageLeftText = ({
         <CardMedia
           className={classes.rightCardMedia}
           component='img'
+          alt=''
           image={imageSrc}
         />
       </Card>


### PR DESCRIPTION
Gave a null alt tag (alt='') for images on collaborate page as mentioned W3.org accessibility tutorials

Closes #1106 