### PR TITLE
Fix organizations data tree in org page

### DIFF
--- a/cypress/integration/pages/organizations.spec.js
+++ b/cypress/integration/pages/organizations.spec.js
@@ -4,6 +4,8 @@ describe('Organizations Page (using API)', () => {
   const parentOrg = 'Code for America';
   const affiliatedOrg = 'Code for ABQ';
   const affiliatedOrgPartial = 'ABQ';
+  const affiliatedOrg2 = 'Code for Aomori';
+  const affiliatedOrg2Partial = 'Code for A';
   const parentOrgCount1 = 24;
   const parentOrgCount2 = 1;
 
@@ -85,9 +87,41 @@ describe('Organizations Page (using API)', () => {
     cy.get('[data-cy=organization-search-list]').click();
     cy.get('[data-cy=affiliated-organizations]').within(() => {
       cy.get('[data-cy=thumbnail-dropdown]').should('have.length', 1);
-      cy.get('[data-cy=thumbnail-dropdown]').eq(0).click().within(() => {
-        cy.get('[data-cy=contributor-thumbnail-text]').contains(affiliatedOrg);
-      });
+      cy.get('[data-cy=thumbnail-dropdown]')
+        .eq(0)
+        .click()
+        .within(() => {
+          cy.get('[data-cy=contributor-thumbnail-text]').contains(
+            affiliatedOrg
+          );
+        });
+    });
+    cy.get('[data-cy=organization-search]').within(() => {
+      cy.get('input').clear();
+    });
+  });
+
+  it('should find affiliatedOrg2 via partial search', () => {
+    cy.intercept(`${Cypress.env('REACT_APP_API_URL')}/api/organizations/`).as(
+      'getOrganizations'
+    );
+    cy.visit('/organizations', {
+      qs: { contrib: false, status: 'affiliated' },
+    });
+    cy.wait('@getOrganizations');
+    cy.get('[data-cy=organization-search]')
+      .type(affiliatedOrg2Partial)
+      .type('{Enter}');
+    cy.get('[data-cy=affiliated-organizations]').within(() => {
+      cy.get('[data-cy=thumbnail-dropdown]').should('have.length', 4);
+      cy.get('[data-cy=thumbnail-dropdown]')
+        .eq(3)
+        .click()
+        .within(() => {
+          cy.get('[data-cy=contributor-thumbnail-text]').contains(
+            affiliatedOrg2
+          );
+        });
     });
     cy.get('[data-cy=organization-search]').within(() => {
       cy.get('input').clear();

--- a/cypress/integration/pages/organizations.spec.js
+++ b/cypress/integration/pages/organizations.spec.js
@@ -42,14 +42,14 @@ describe('Organizations Page (using API)', () => {
     cy.wait('@getOrganizations');
     cy.get('[data-cy=index-contributors-checkbox] input:checkbox').uncheck();
     cy.contains(grandparentOrg).should('have.length', 1);
-    cy.get('[data-cy=code-for-all-chevron]').click();
+    cy.get('[class*=makeStyles-chevron]').eq(0).click();
     cy.get('[data-cy=affiliated-organizations]').within(() => {
       cy.get('[data-cy=thumbnail-dropdown]').should('have.length', parentOrgCount1);
       cy.get('[data-cy=thumbnail-dropdown]')
         .contains(parentOrg)
         .parentsUntil('[data-cy=thumbnail-dropdown]')
         .within(() => {
-          cy.get('[data-cy=dropdown-chevron]').click();
+          cy.get('[class*=makeStyles-chevron]').click();
         });
       cy.contains(affiliatedOrg);
     });
@@ -121,7 +121,7 @@ describe('Organizations Page (using fixture)', () => {
   });
 
   it('should load 24 affiliated orgs', () => {
-    cy.get('[class*=makeStyles-gpGrid]').click();
+    cy.get('[class*=makeStyles-chevron]').eq(0).click();
     cy.get('[data-cy=affiliated-organizations]').within(() => {
       cy.get('[data-cy=thumbnail-dropdown]').should('have.length', 24);
     });
@@ -189,17 +189,19 @@ describe('Organizations Page (using fixture)', () => {
   });
 
   it('should show grandparent org in closed state', () => {
-    cy.get('[class*=makeStyles-gpGrid]')
-      .invoke('attr', 'class')
-      .should('not.contain', 'makeStyles-open');
+    cy.get('[class*=makeStyles-chevron]')
+      .eq(0)
+      .get('[data-cy=dropdown-chevron-closed]')
+      .should('exist');
     cy.get('[class*=makeStyles-dropDownGrid]').should('not.exist');
   });
 
   it('should open grandparent org and show parent orgs', () => {
-    cy.get('[class*=makeStyles-gpGrid]').click();
-    cy.get('[class*=makeStyles-gpGrid]')
-      .invoke('attr', 'class')
-      .should('contain', 'makeStyles-open');
+    cy.get('[class*=makeStyles-chevron]').eq(0).click();
+    cy.get('[class*=makeStyles-chevron]')
+      .eq(0)
+      .get('[data-cy=dropdown-chevron-open]')
+      .should('exist');
     cy.get('[class*=makeStyles-dropDownGrid]').should('exist');
     cy.get('[class*=makeStyles-dropDownGrid]').within(() => {
       cy.contains('Code for America').should('exist');
@@ -275,8 +277,8 @@ describe('Organizations Page (using fixture)', () => {
     cy.get('[data-cy=index-contributors-checkbox]').within(() => {
       cy.get('[type="checkbox"]').should('not.be.checked');
     });
-    cy.get('[class*=makeStyles-gpGrid]').within(() => {
       cy.get('[class*=contributorIcon]').should('not.exist');
+    cy.get('[class*=makeStyles-dropdown]').within(() => {
     });
     cy.get('[class*=makeStyles-dropDownGrid]').within(() => {
       cy.contains('Code for America')
@@ -297,9 +299,11 @@ describe('Organizations Page (using fixture)', () => {
     cy.visit('/organizations', { qs: { contrib: false, status: 'affiliated' }});
     cy.wait('@getOrganizations');
     cy.get('[data-cy=index-contributors-checkbox] input:checkbox').check();
-    cy.get('[class*=makeStyles-gpGrid]').within(() => {
-      cy.get('[class*=contributorIcon]').should('exist');
-    });
+    cy.get('[class*=makeStyles-dropdown]')
+      .eq(0)
+      .within(() => {
+        cy.get('[data-cy=contributor-icon]').should('exist');
+      });
     // cy.get('[data-cy=contributor-icon]').should('have.length', 25);
     cy.get('[class*=makeStyles-dropDownGrid]').within(() => {
       cy.contains('Code for America').parent().parent().parent().within(() => {

--- a/cypress/integration/pages/organizations.spec.js
+++ b/cypress/integration/pages/organizations.spec.js
@@ -311,9 +311,7 @@ describe('Organizations Page (using fixture)', () => {
     cy.get('[data-cy=index-contributors-checkbox]').within(() => {
       cy.get('[type="checkbox"]').should('not.be.checked');
     });
-      cy.get('[class*=contributorIcon]').should('not.exist');
-    cy.get('[class*=makeStyles-dropdown]').within(() => {
-    });
+    cy.get('[class*=contributorIcon]').should('not.exist');
     cy.get('[class*=makeStyles-dropDownGrid]').within(() => {
       cy.contains('Code for America')
         .parent()

--- a/src/components/ContributorThumbnail.js
+++ b/src/components/ContributorThumbnail.js
@@ -141,7 +141,6 @@ export const ContributorThumbnail = ({
   dropdownLength,
   isChildThumbnail,
   checkboxValue,
-  inputValue,
   filtersActive,
 }) => {
   const classes = useStyles();
@@ -162,7 +161,6 @@ export const ContributorThumbnail = ({
             dropdownLength={dropdownLength}
             isChildThumbnail={isChildThumbnail}
             checkboxValue={checkboxValue}
-            inputValue={inputValue}
             filtersActive={filtersActive}
           />
         ) : (

--- a/src/components/ContributorThumbnail.js
+++ b/src/components/ContributorThumbnail.js
@@ -223,13 +223,13 @@ const Thumbnail = ({
         {organization.depth === 4 &&
         checkboxValue &&
         organization.cti_contributor ? (
-          <img
-            alt='contributor-icon'
-            data-cy='contributor-icon'
-            className={classes.contributorIcon}
-            src='/images/Child_contributed.svg'
-          />
-        ) : null}
+            <img
+              alt='contributor-icon'
+              data-cy='contributor-icon'
+              className={classes.contributorIcon}
+              src='/images/Child_contributed.svg'
+            />
+          ) : null}
       </Box>
       <Grid className={thumbnailWrapperStyle}>
         <Grid item className={classes.imageWrapper}>

--- a/src/components/ContributorThumbnail.js
+++ b/src/components/ContributorThumbnail.js
@@ -71,6 +71,11 @@ const useStyles = makeStyles((theme) => ({
       fontSize: '18px',
     },
   },
+  grandparentText: {
+    [theme.breakpoints.up('lg')]: {
+      fontSize: '24px',
+    },
+  },
   grandparentIcon: {
     marginTop: '22%',
     marginLeft: '13%',
@@ -211,19 +216,22 @@ const Thumbnail = ({
     return displayedCount;
   };
 
+  const showGrandparentText =
+    'childNodes' in organization && organization.depth === 2;
+
   return (
     <>
       <Box className={classes.contributorItem}>
         {organization.depth === 4 &&
         checkboxValue &&
         organization.cti_contributor ? (
-            <img
-              alt='contributor-icon'
-              data-cy='contributor-icon'
-              className={classes.contributorIcon}
-              src='/images/Child_contributed.svg'
-            />
-          ) : null}
+          <img
+            alt='contributor-icon'
+            data-cy='contributor-icon'
+            className={classes.contributorIcon}
+            src='/images/Child_contributed.svg'
+          />
+        ) : null}
       </Box>
       <Grid className={thumbnailWrapperStyle}>
         <Grid item className={classes.imageWrapper}>
@@ -247,9 +255,10 @@ const Thumbnail = ({
             aria-level={isChildThumbnail ? '4' : '3'}
             noWrap
             data-cy='contributor-thumbnail-text'
-            className={
-              isOpen ? `${classes.blueColorText}` : `${classes.orgText}`
-            }
+            className={`
+              ${isOpen ? classes.blueColorText : classes.orgText}
+              ${showGrandparentText ? classes.grandparentText : null}
+            `}
           >
             <Link
               href={`/organization/${organization.slug}`}

--- a/src/components/ContributorThumbnail.js
+++ b/src/components/ContributorThumbnail.js
@@ -271,7 +271,7 @@ const Thumbnail = ({
         </Grid>
         <Grid>
           <Typography>
-            {organization.depth === 3 && checkboxValue ? (
+            {organization.childNodes?.length > 0 && checkboxValue ? (
               <img
                 alt='contributor-icon'
                 data-cy='contributor-icon'

--- a/src/components/DropdownArrow.js
+++ b/src/components/DropdownArrow.js
@@ -35,8 +35,19 @@ export const DropdownArrow  = ({ open,handleOpen }) => {
 
   return (
     <>
-      {open ? <ExpandLessRoundedIcon data-cy="dropdown-chevron" className={classes.clickDropDown} onClick={handleOpen} />
-        : <ExpandMoreRoundedIcon data-cy="dropdown-chevron"  className={classes.chevron}  onClick={()=>handleClick}/>}
+      {open ? (
+        <ExpandLessRoundedIcon
+          data-cy='dropdown-chevron-open'
+          className={classes.clickDropDown}
+          onClick={handleOpen}
+        />
+      ) : (
+        <ExpandMoreRoundedIcon
+          data-cy='dropdown-chevron-closed'
+          className={classes.chevron}
+          onClick={() => handleClick}
+        />
+      )}
     </>
   );
 

--- a/src/pages/Contributors/Affiliated.js
+++ b/src/pages/Contributors/Affiliated.js
@@ -160,7 +160,7 @@ export const Affiliated = ({
         );
 
         if (!grandparentObj) {
-          if (!showIndexContrib) {
+          if (!filtersActive) {
             console.error(new Error('grandparent of depth 4 node not found'));
             return;
           }
@@ -242,7 +242,7 @@ export const Affiliated = ({
               return count + nodeCount;
             }, 0)}
             filtersActive={filtersActive}
-            isOpen={expandedOrgs.includes(org.id.toString())}
+            isOpen={filtersActive || expandedOrgs.includes(org.id.toString())}
             key={`affiliatedThumbnailsWrapper_${i}`}
             onClick={onOrgClick}
             organization={org}

--- a/src/pages/Contributors/Affiliated.js
+++ b/src/pages/Contributors/Affiliated.js
@@ -204,9 +204,25 @@ export const Affiliated = ({
         );
 
         if (!parentObj) {
-          console.error(
-            new Error('parent of depth 3 not found in grandparentObj')
+          if (!filtersActive) {
+            console.error(
+              new Error('parent of depth 3 not found in grandparentObj')
+            );
+          }
+
+          // find parent of depth 3 and assign as child of grandparent
+          const parent = organizationData.find(
+            (d) => org.path.includes(d.path) && d.depth === 3
           );
+          if (!parent) {
+            console.error(
+              new Error('parent of depth 3 node not found in organizationData')
+            );
+            return;
+          }
+          parent['childNodes'] = [];
+          grandparentObj.childNodes.push(parent);
+          parent.childNodes.push(org);
         } else {
           parentObj.childNodes.push(org);
         }

--- a/src/pages/Contributors/Affiliated.js
+++ b/src/pages/Contributors/Affiliated.js
@@ -236,10 +236,7 @@ export const Affiliated = ({
         <div key={org.path}>
           <Dropdown
             checkboxValue={showIndexContrib}
-            dropdownLength={org.childNodes.reduce(
-              (total, node) => total + (node.childNodes.length + 1),
-              0
-            )}
+            dropdownLength={org.totalCount}
             filtersActive={filtersActive}
             isOpen={expandedOrgs.includes(org.id.toString())}
             key={`affiliatedThumbnailsWrapper_${i}`}

--- a/src/pages/Contributors/Affiliated.js
+++ b/src/pages/Contributors/Affiliated.js
@@ -236,7 +236,10 @@ export const Affiliated = ({
         <div key={org.path}>
           <Dropdown
             checkboxValue={showIndexContrib}
-            dropdownLength={org.childNodes.length}
+            dropdownLength={org.childNodes.reduce(
+              (total, node) => total + (node.childNodes.length + 1),
+              0
+            )}
             filtersActive={filtersActive}
             isOpen={expandedOrgs.includes(org.id.toString())}
             key={`affiliatedThumbnailsWrapper_${i}`}

--- a/src/pages/Contributors/Affiliated.js
+++ b/src/pages/Contributors/Affiliated.js
@@ -133,7 +133,7 @@ export const Affiliated = ({
   const classesLocal = useStyles();
   const [orgTree, setOrgTree] = useState([]);
 
-  const getParentData = () => {
+  const buildOrgTree = () => {
     const parentdata = [];
     let parentObj;
 
@@ -232,7 +232,7 @@ export const Affiliated = ({
   };
 
   useEffect(() => {
-    setOrgTree(getParentData());
+    setOrgTree(buildOrgTree());
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [organizations]);
 

--- a/src/pages/Contributors/Affiliated.js
+++ b/src/pages/Contributors/Affiliated.js
@@ -236,7 +236,11 @@ export const Affiliated = ({
         <div key={org.path}>
           <Dropdown
             checkboxValue={showIndexContrib}
-            dropdownLength={org.totalCount}
+            dropdownLength={org.childNodes.reduce((count, item) => {
+              const nodeCount =
+                item.childNodes.length === 0 ? 1 : item.childNodes.length;
+              return count + nodeCount;
+            }, 0)}
             filtersActive={filtersActive}
             isOpen={expandedOrgs.includes(org.id.toString())}
             key={`affiliatedThumbnailsWrapper_${i}`}

--- a/src/pages/Contributors/Affiliated.js
+++ b/src/pages/Contributors/Affiliated.js
@@ -132,14 +132,6 @@ export const Affiliated = ({
 }) => {
   const classesLocal = useStyles();
   const [orgTree, setOrgTree] = useState([]);
-  const [dropdownOpen, setDropdownOpen] = useState(false);
-  useEffect(() => {
-    if ((filtersActive || expandedOrgs.length) && organizations.length) {
-      setDropdownOpen(true);
-    } else {
-      setDropdownOpen(false);
-    }
-  }, [expandedOrgs, filtersActive, organizations]);
 
   const getParentData = () => {
     const parentdata = [];
@@ -159,7 +151,7 @@ export const Affiliated = ({
           parentObj.childNodes.push(org);
         } else {
           // do we ever get here?
-          console.error('XXXX parent of depth 3 node not found');
+          console.error(new Error('parent of depth 3 node not found'));
         }
       }
       if (org.depth === 4) {
@@ -169,8 +161,7 @@ export const Affiliated = ({
 
         if (!grandparentObj) {
           if (!showIndexContrib) {
-            console.error('XXXX grandparent of depth 4 node not found');
-            console.log(org);
+            console.error(new Error('grandparent of depth 4 node not found'));
             return;
           }
 
@@ -184,7 +175,9 @@ export const Affiliated = ({
           );
           if (!grandparentObj) {
             console.error(
-              'XXXX grandparent of depth 2 node not found in organizationData'
+              new Error(
+                'grandparent of depth 2 node not found in organizationData'
+              )
             );
             return;
           }
@@ -197,7 +190,7 @@ export const Affiliated = ({
           );
           if (!parent) {
             console.error(
-              'XXXX parent of depth 3 node not found in organizationData'
+              new Error('parent of depth 3 node not found in organizationData')
             );
             return;
           }
@@ -211,8 +204,9 @@ export const Affiliated = ({
         );
 
         if (!parentObj) {
-          // do we ever get here?
-          console.error('XXXX parent of depth 3 not found in grandparentObj');
+          console.error(
+            new Error('parent of depth 3 not found in grandparentObj')
+          );
         } else {
           parentObj.childNodes.push(org);
         }

--- a/src/pages/Contributors/Affiliated.js
+++ b/src/pages/Contributors/Affiliated.js
@@ -132,6 +132,8 @@ export const Affiliated = ({
   const classesLocal = useStyles();
   const [dropdownOpen, setDropdownOpen] = useState(false);
   useEffect(() => {
+    // console.log(organizationData)
+    // console.log(organizations)
     if ((filtersActive || expandedOrgs.length) && organizations.length) {
       setDropdownOpen(true);
     } else {

--- a/src/pages/Contributors/Affiliated.js
+++ b/src/pages/Contributors/Affiliated.js
@@ -148,7 +148,6 @@ export const Affiliated = ({
     organizations.forEach((org) => {
       if (org.depth === 2) {
         org['childNodes'] = [];
-        org['allChildrenShown'] = false;
         parentdata.push(org);
       }
       if (org.depth === 3) {
@@ -157,7 +156,6 @@ export const Affiliated = ({
         });
         if (parentObj) {
           org['childNodes'] = [];
-          org['allChildrenShown'] = false;
           parentObj.childNodes.push(org);
         } else {
           // do we ever get here?
@@ -191,7 +189,6 @@ export const Affiliated = ({
             return;
           }
           grandparentObj['childNodes'] = [];
-          grandparentObj['allChildrenShown'] = false;
           parentdata.push(grandparentObj);
 
           // find parent of depth 3 and assign as child of grandparent
@@ -205,7 +202,6 @@ export const Affiliated = ({
             return;
           }
           parent['childNodes'] = [];
-          parent['allChildrenShown'] = false;
           grandparentObj.childNodes.push(parent);
         }
 
@@ -222,7 +218,6 @@ export const Affiliated = ({
         }
       }
     });
-    console.log(parentdata);
     return parentdata;
   };
 

--- a/src/pages/Contributors/AffiliatedOrganizations.js
+++ b/src/pages/Contributors/AffiliatedOrganizations.js
@@ -68,16 +68,14 @@ export const AffiliatedOrganizations = ({
   filtersActive,
   inputValue,
   onOrgClick,
-  organizationData,
-  organizations,
+  organizations, // affiliated orgs
   showIndexContrib,
 }) => {
   const classes = useStyles();
 
   const isChildThumbnail = true;
   let parentdata;
-  let parentChildobj;
-  let mapsearchedChildParent;
+  let parentObj;
 
   const getParentData = () => {
     parentdata = [];
@@ -90,65 +88,94 @@ export const AffiliatedOrganizations = ({
       }
       if (org.depth === 3) {
         // console.log(parentdata);
-        parentChildobj = parentdata.find((d) => {
+        parentObj = parentdata.find((d) => {
           // console.log(org.path, d.path);
           return org.path.includes(d.path) && d.depth === 2;
         });
-        if (parentChildobj) {
-          parentChildobj.childNodes.push(org);
-        } else {
+        if (parentObj) {
           org['childNodes'] = [];
           org['allChildrenShown'] = false;
-          parentdata.push(org);
+          parentObj.childNodes.push(org);
+        } else {
+          // do we ever get here?
+          console.error('XXXX parent of depth 3 node not found');
+          // org['childNodes'] = [];
+          // org['allChildrenShown'] = false;
+          // parentdata.push(org);
         }
       }
       if (org.depth === 4) {
-        // parentChildobj = parentdata.find((d) => org.path.includes(d.path));
-        parentChildobj = [];
+        const grandparentObj = parentdata.find(
+          (d) => org.path.includes(d.path) && d.depth === 2
+        );
 
+        if (!grandparentObj) {
+          console.error('XXXX grandparent of depth 4 node not found');
+          console.log(org);
+          return;
+        }
+
+        // loop through grandparent to find parent
+        parentObj = grandparentObj['childNodes'].find((d) =>
+          org.path.includes(d.path)
+        );
+
+        /*
         // potential parent: common path and one level higher
         // I don't see  how this could find any more than one parent unless
         // there's some data corruption
         mapsearchedChildParent = organizationData.find(
           (d) => org.path.includes(d.path) && d.depth === 3
         );
+        // console.log(mapsearchedChildParent);
 
-        // see if parent is already included previously. Why?
-        const exist = parentdata.find(
-          (d) => mapsearchedChildParent.path === d.path
-        );
-
-        // set the parent we're going to use
-        if (!exist) {
-          // parent not found in accumulated list
-          // set the potential parent as the parent anyway
-          mapsearchedChildParent['childNodes'] = [];
-          mapsearchedChildParent['allChildrenShown'] = false;
-          parentChildobj = mapsearchedChildParent;
-          parentdata.push(mapsearchedChildParent);
-          // do we ever get here?
-          console.error('XXXX');
+        // NEW find potential grandparent
+        if (!mapsearchedChildParent) {
+          console.log('re-search for grandparent');
+          mapsearchedChildParent = organizationData.find(
+            (d) => org.path.includes(d.path) && d.depth === 2
+          );
         } else {
-          // set the found parent as parent
-          parentChildobj = exist;
+          // see if parent is already included previously. Why?
+          const exist = parentdata.find(
+            (d) => mapsearchedChildParent.path === d.path
+          );
+
+          // set the parent we're going to use
+          if (!exist) {
+            // parent not found in accumulated list
+            // set the potential parent as the parent anyway
+            mapsearchedChildParent['childNodes'] = [];
+            mapsearchedChildParent['allChildrenShown'] = false;
+            parentChildobj = mapsearchedChildParent;
+            parentdata.push(mapsearchedChildParent);
+            // do we ever get here?
+            console.error('XXXX');
+            console.log(mapsearchedChildParent);
+          } else {
+            // set the found parent as parent
+            parentChildobj = exist;
+          }
         }
+        */
 
         // apply show/hide filter
         // this would probably be more efficient if done to the entire array at
         // once
-        if (parentChildobj) {
+        if (parentObj) {
+          // console.log(parentObj);
           if (showIndexContrib && org['cti_contributor']) {
-            parentChildobj.childNodes.push(org);
+            parentObj.childNodes.push(org);
           }
           if (!showIndexContrib) {
-            parentChildobj.childNodes.push(org);
+            parentObj.childNodes.push(org);
           }
         } else {
-          org['childNodes'] = [];
-          org['allChildrenShown'] = false;
-          parentdata.push(org);
           // do we ever get here?
           console.error('XXXX');
+          // org['childNodes'] = [];
+          // org['allChildrenShown'] = false;
+          // parentdata.push(org);
         }
       }
     });

--- a/src/pages/Contributors/AffiliatedOrganizations.js
+++ b/src/pages/Contributors/AffiliatedOrganizations.js
@@ -89,16 +89,18 @@ export const AffiliatedOrganizations = ({
         parentdata.push(org);
       }
       if (org.depth === 3) {
-        console.log(parentdata);
+        // console.log(parentdata);
         parentChildobj = parentdata.find((d) => {
-          console.log(org.path, d.path);
+          // console.log(org.path, d.path);
           return org.path.includes(d.path) && d.depth === 2;
         });
-        parentChildobj.childNodes.push(org);
-
-        org['childNodes'] = [];
-        org['allChildrenShown'] = false;
-        parentdata.push(org);
+        if (parentChildobj) {
+          parentChildobj.childNodes.push(org);
+        } else {
+          org['childNodes'] = [];
+          org['allChildrenShown'] = false;
+          parentdata.push(org);
+        }
       }
       if (org.depth === 4) {
         // parentChildobj = parentdata.find((d) => org.path.includes(d.path));
@@ -124,6 +126,8 @@ export const AffiliatedOrganizations = ({
           mapsearchedChildParent['allChildrenShown'] = false;
           parentChildobj = mapsearchedChildParent;
           parentdata.push(mapsearchedChildParent);
+          // do we ever get here?
+          console.error('XXXX');
         } else {
           // set the found parent as parent
           parentChildobj = exist;
@@ -143,6 +147,8 @@ export const AffiliatedOrganizations = ({
           org['childNodes'] = [];
           org['allChildrenShown'] = false;
           parentdata.push(org);
+          // do we ever get here?
+          console.error('XXXX');
         }
       }
     });

--- a/src/pages/Contributors/AffiliatedOrganizations.js
+++ b/src/pages/Contributors/AffiliatedOrganizations.js
@@ -68,127 +68,13 @@ export const AffiliatedOrganizations = ({
   filtersActive,
   inputValue,
   onOrgClick,
-  organizations, // affiliated orgs
+  orgTree,
+  setOrgTree,
   showIndexContrib,
 }) => {
   const classes = useStyles();
 
   const isChildThumbnail = true;
-  let parentdata;
-  let parentObj;
-
-  const getParentData = () => {
-    parentdata = [];
-
-    organizations.forEach((org) => {
-      if (org.depth === 2) {
-        org['childNodes'] = [];
-        org['allChildrenShown'] = false;
-        parentdata.push(org);
-      }
-      if (org.depth === 3) {
-        // console.log(parentdata);
-        parentObj = parentdata.find((d) => {
-          // console.log(org.path, d.path);
-          return org.path.includes(d.path) && d.depth === 2;
-        });
-        if (parentObj) {
-          org['childNodes'] = [];
-          org['allChildrenShown'] = false;
-          parentObj.childNodes.push(org);
-        } else {
-          // do we ever get here?
-          console.error('XXXX parent of depth 3 node not found');
-          // org['childNodes'] = [];
-          // org['allChildrenShown'] = false;
-          // parentdata.push(org);
-        }
-      }
-      if (org.depth === 4) {
-        const grandparentObj = parentdata.find(
-          (d) => org.path.includes(d.path) && d.depth === 2
-        );
-
-        if (!grandparentObj) {
-          console.error('XXXX grandparent of depth 4 node not found');
-          console.log(org);
-          return;
-        }
-
-        // loop through grandparent to find parent
-        parentObj = grandparentObj['childNodes'].find((d) =>
-          org.path.includes(d.path)
-        );
-
-        /*
-        // potential parent: common path and one level higher
-        // I don't see  how this could find any more than one parent unless
-        // there's some data corruption
-        mapsearchedChildParent = organizationData.find(
-          (d) => org.path.includes(d.path) && d.depth === 3
-        );
-        // console.log(mapsearchedChildParent);
-
-        // NEW find potential grandparent
-        if (!mapsearchedChildParent) {
-          console.log('re-search for grandparent');
-          mapsearchedChildParent = organizationData.find(
-            (d) => org.path.includes(d.path) && d.depth === 2
-          );
-        } else {
-          // see if parent is already included previously. Why?
-          const exist = parentdata.find(
-            (d) => mapsearchedChildParent.path === d.path
-          );
-
-          // set the parent we're going to use
-          if (!exist) {
-            // parent not found in accumulated list
-            // set the potential parent as the parent anyway
-            mapsearchedChildParent['childNodes'] = [];
-            mapsearchedChildParent['allChildrenShown'] = false;
-            parentChildobj = mapsearchedChildParent;
-            parentdata.push(mapsearchedChildParent);
-            // do we ever get here?
-            console.error('XXXX');
-            console.log(mapsearchedChildParent);
-          } else {
-            // set the found parent as parent
-            parentChildobj = exist;
-          }
-        }
-        */
-
-        // apply show/hide filter
-        // this would probably be more efficient if done to the entire array at
-        // once
-        if (parentObj) {
-          // console.log(parentObj);
-          if (showIndexContrib && org['cti_contributor']) {
-            parentObj.childNodes.push(org);
-          }
-          if (!showIndexContrib) {
-            parentObj.childNodes.push(org);
-          }
-        } else {
-          // do we ever get here?
-          console.error('XXXX');
-          // org['childNodes'] = [];
-          // org['allChildrenShown'] = false;
-          // parentdata.push(org);
-        }
-      }
-    });
-    console.log(parentdata);
-    return parentdata;
-  };
-
-  const [orgTree, setOrgTree] = useState([]);
-
-  useEffect(() => {
-    setOrgTree(getParentData());
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [organizations]);
 
   let childSort;
   let childNode;

--- a/src/pages/Contributors/AffiliatedOrganizations.js
+++ b/src/pages/Contributors/AffiliatedOrganizations.js
@@ -83,31 +83,55 @@ export const AffiliatedOrganizations = ({
     parentdata = [];
 
     organizations.forEach((org) => {
+      if (org.depth === 2) {
+        org['childNodes'] = [];
+        org['allChildrenShown'] = false;
+        parentdata.push(org);
+      }
       if (org.depth === 3) {
+        console.log(parentdata);
+        parentChildobj = parentdata.find((d) => {
+          console.log(org.path, d.path);
+          return org.path.includes(d.path) && d.depth === 2;
+        });
+        parentChildobj.childNodes.push(org);
+
         org['childNodes'] = [];
         org['allChildrenShown'] = false;
         parentdata.push(org);
       }
       if (org.depth === 4) {
-        parentChildobj = parentdata.find((d) => org.path.includes(d.path));
+        // parentChildobj = parentdata.find((d) => org.path.includes(d.path));
+        parentChildobj = [];
 
+        // potential parent: common path and one level higher
+        // I don't see  how this could find any more than one parent unless
+        // there's some data corruption
         mapsearchedChildParent = organizationData.find(
           (d) => org.path.includes(d.path) && d.depth === 3
         );
 
+        // see if parent is already included previously. Why?
         const exist = parentdata.find(
           (d) => mapsearchedChildParent.path === d.path
         );
 
+        // set the parent we're going to use
         if (!exist) {
+          // parent not found in accumulated list
+          // set the potential parent as the parent anyway
           mapsearchedChildParent['childNodes'] = [];
           mapsearchedChildParent['allChildrenShown'] = false;
           parentChildobj = mapsearchedChildParent;
           parentdata.push(mapsearchedChildParent);
         } else {
+          // set the found parent as parent
           parentChildobj = exist;
         }
 
+        // apply show/hide filter
+        // this would probably be more efficient if done to the entire array at
+        // once
         if (parentChildobj) {
           if (showIndexContrib && org['cti_contributor']) {
             parentChildobj.childNodes.push(org);
@@ -122,6 +146,7 @@ export const AffiliatedOrganizations = ({
         }
       }
     });
+    console.log(parentdata);
     return parentdata;
   };
 

--- a/src/pages/Contributors/AffiliatedOrganizations.js
+++ b/src/pages/Contributors/AffiliatedOrganizations.js
@@ -183,11 +183,11 @@ export const AffiliatedOrganizations = ({
     return parentdata;
   };
 
-  const [currentThumbnails, setCurrentThumbnails] = useState([]);
+  const [orgTree, setOrgTree] = useState([]);
 
   useEffect(() => {
-    setCurrentThumbnails(getParentData());
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    setOrgTree(getParentData());
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [organizations]);
 
   let childSort;
@@ -196,10 +196,10 @@ export const AffiliatedOrganizations = ({
     return (
       <Grid
         className={classes.thumbnailGrid}
-        dropdownlength={currentThumbnails.length}
+        dropdownlength={orgTree.length}
         data-cy='affiliated-organizations'
       >
-        {currentThumbnails.map((org, i) => {
+        {orgTree.map((org, i) => {
           childSort = org.childNodes;
           childNode = org.allChildrenShown ? childSort : childSort.slice(0, 6);
           return (
@@ -266,12 +266,12 @@ export const AffiliatedOrganizations = ({
                       id='viewAllButton'
                       className={classes.button}
                       onClick={() => {
-                        const data = [...currentThumbnails];
+                        const data = [...orgTree];
                         data[i].allChildrenShown = !data[i].allChildrenShown;
-                        setCurrentThumbnails(data);
+                        setOrgTree(data);
                       }}
                     >
-                      {currentThumbnails[i].allChildrenShown ? 'View Less' : 'View All'}
+                      {orgTree[i].allChildrenShown ? 'View Less' : 'View All'}
                     </Button>
                   </Grid>
                 ) : null}
@@ -287,7 +287,7 @@ export const AffiliatedOrganizations = ({
         className={classes.thumbnailGrid}
         data-cy='affiliated-organizations'
       >
-        {currentThumbnails.map((org, i) => {
+        {orgTree.map((org, i) => {
           return (
             <Dropdown
               checkboxValue={showIndexContrib}

--- a/src/pages/Contributors/AffiliatedOrganizations.js
+++ b/src/pages/Contributors/AffiliatedOrganizations.js
@@ -2,6 +2,7 @@
 /* eslint-disable complexity */
 
 import React, { useState, useEffect } from 'react';
+import { ArrayParam, useQueryParam, withDefault } from 'use-query-params';
 import { Dropdown } from '../../components/Dropdown';
 import { ContributorThumbnail } from '../../components/ContributorThumbnail';
 import Button from '@material-ui/core/Button';
@@ -75,6 +76,21 @@ export const AffiliatedOrganizations = ({
   const classes = useStyles();
 
   const isChildThumbnail = true;
+  const [viewAllChildren, setViewAllChildren] = useQueryParam(
+    'hidden',
+    withDefault(ArrayParam, [])
+  );
+
+  const handleViewAllClick = (i) => {
+    const viewAll = [...viewAllChildren];
+    const idx = viewAll.indexOf(orgTree[i].id.toString());
+    if (idx > -1) {
+      viewAll.splice(idx, 1);
+    } else {
+      viewAll.push(orgTree[i].id.toString());
+    }
+    setViewAllChildren(viewAll);
+  };
 
   let childSort;
   let childNode;
@@ -87,7 +103,9 @@ export const AffiliatedOrganizations = ({
       >
         {orgTree.map((org, i) => {
           childSort = org.childNodes;
-          childNode = org.allChildrenShown ? childSort : childSort.slice(0, 6);
+          childNode = viewAllChildren.includes(org.id.toString())
+            ? childSort
+            : childSort.slice(0, 6);
           return (
             <Dropdown
               checkboxValue={showIndexContrib}
@@ -152,12 +170,12 @@ export const AffiliatedOrganizations = ({
                       id='viewAllButton'
                       className={classes.button}
                       onClick={() => {
-                        const data = [...orgTree];
-                        data[i].allChildrenShown = !data[i].allChildrenShown;
-                        setOrgTree(data);
+                        handleViewAllClick(i);
                       }}
                     >
-                      {orgTree[i].allChildrenShown ? 'View Less' : 'View All'}
+                      {viewAllChildren.includes(org.id.toString())
+                        ? 'View Less'
+                        : 'View All'}
                     </Button>
                   </Grid>
                 ) : null}

--- a/src/pages/Contributors/AffiliatedOrganizations.js
+++ b/src/pages/Contributors/AffiliatedOrganizations.js
@@ -76,10 +76,7 @@ export const AffiliatedOrganizations = ({
   const classes = useStyles();
 
   const isChildThumbnail = true;
-  const [viewAllChildren, setViewAllChildren] = useQueryParam(
-    'hidden',
-    withDefault(ArrayParam, [])
-  );
+  const [viewAllChildren, setViewAllChildren] = useState([]);
 
   const handleViewAllClick = (i) => {
     const viewAll = [...viewAllChildren];

--- a/src/pages/Contributors/index.js
+++ b/src/pages/Contributors/index.js
@@ -123,10 +123,6 @@ export default function Contributors() {
       setOrganizationNames(names.sort());
       setTotalAffiliatedCount(totalAfflCount);
       setTotalUnaffiliatedCount(totalUnafflCount);
-      if (!filtersActive) {
-        setAffiliatedCount(totalAfflCount);
-        setUnaffiliatedCount(totalUnafflCount);
-      }
     };
     fetchData();
   }, []);
@@ -190,13 +186,8 @@ export default function Contributors() {
     }
     const hasFilter = !!input || showIndexContrib;
     setFiltersActive(hasFilter);
-    if (hasFilter) {
-      setAffiliatedCount(affiliated.length);
-      setUnaffiliatedCount(unaffiliated.length);
-    } else {
-      setAffiliatedCount(totalAffiliatedCount);
-      setUnaffiliatedCount(totalUnaffiliatedCount);
-    }
+    setAffiliatedCount(affiliated.length);
+    setUnaffiliatedCount(unaffiliated.length);
     setAffiliatedOrganizations(affiliated);
     setUnaffiliatedOrganizations(unaffiliated);
     setLoading(false);

--- a/src/pages/Contributors/index.js
+++ b/src/pages/Contributors/index.js
@@ -154,8 +154,6 @@ export default function Contributors() {
   }, [location.search, setOrgStatus, setShowIndexContrib]);
 
   useEffect(() => {
-    let afflCount = 0,
-      unafflCount = 0;
     const affiliated = [];
     const unaffiliated = [];
     const input = searchQuery.toLowerCase().replace(/\s/g, '');
@@ -166,11 +164,9 @@ export default function Contributors() {
         orgName.includes(input)
       ) {
         if (org.affiliated) {
-          afflCount++;
           setLoading(true);
           affiliated.push(org);
         } else if (!org.affiliated) {
-          unafflCount++;
           setLoading(true);
           unaffiliated.push(org);
         } else {
@@ -179,8 +175,8 @@ export default function Contributors() {
       }
     }
     setFiltersActive(!!input || showIndexContrib);
-    setAffiliatedCount(afflCount);
-    setUnaffiliatedCount(unafflCount);
+    setAffiliatedCount(affiliated.length);
+    setUnaffiliatedCount(unaffiliated.length);
     setAffiliatedOrganizations(affiliated);
     setUnaffiliatedOrganizations(unaffiliated);
   }, [searchQuery, organizations, showIndexContrib]);

--- a/src/pages/Contributors/index.js
+++ b/src/pages/Contributors/index.js
@@ -98,6 +98,9 @@ export default function Contributors() {
           );
           org['totalCount'] = childNodes.length;
         }
+        // if (org.depth === 2) {
+        //   console.log(org)
+        // }
       });
       const names = [];
       let totalAfflCount = 0;
@@ -171,7 +174,7 @@ export default function Contributors() {
         ((showIndexContrib && org.cti_contributor) || !showIndexContrib) &&
         orgName.includes(input)
       ) {
-        if (org.affiliated && org.depth !== 2) {
+        if (org.affiliated) {
           afflCount++;
           setLoading(true);
           affiliated.push(org);

--- a/src/pages/Contributors/index.js
+++ b/src/pages/Contributors/index.js
@@ -90,14 +90,10 @@ export default function Contributors() {
       );
       const sortedOrgs = result.data.sort((a, b) => a.name - b.name);
       sortedOrgs.forEach((org) => {
-        if (org.depth === 3) {
-          const childNodes = sortedOrgs.filter(
-            (item) =>
-              item.depth === 4 &&
-              item.path.substring(0, 12).includes(org.path.substring(0, 12))
-          );
-          org['totalCount'] = childNodes.length;
-        }
+        org['totalCount'] =
+          sortedOrgs.reduce((count, item) => {
+            return count + (item.path.includes(org.path) ? 1 : 0);
+          }, 0) - 1;
       });
       const names = [];
       let totalAfflCount = 0;

--- a/src/pages/Contributors/index.js
+++ b/src/pages/Contributors/index.js
@@ -63,7 +63,7 @@ export default function Contributors() {
   const [totalAffiliatedCount, setTotalAffiliatedCount] = useState(0);
   const [totalUnaffiliatedCount, setTotalUnaffiliatedCount] = useState(0);
   const [unaffiliatedCount, setUnaffiliatedCount] = useState(0);
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
   const [unaffiliatedOrganizations, setUnaffiliatedOrganizations] = useState(
     []
   );
@@ -154,6 +154,7 @@ export default function Contributors() {
   }, [location.search, setOrgStatus, setShowIndexContrib]);
 
   useEffect(() => {
+    setLoading(true);
     const affiliated = [];
     const unaffiliated = [];
     const input = searchQuery.toLowerCase().replace(/\s/g, '');
@@ -164,13 +165,9 @@ export default function Contributors() {
         orgName.includes(input)
       ) {
         if (org.affiliated) {
-          setLoading(true);
           affiliated.push(org);
-        } else if (!org.affiliated) {
-          setLoading(true);
-          unaffiliated.push(org);
         } else {
-          setLoading(false);
+          unaffiliated.push(org);
         }
       }
     }
@@ -179,6 +176,7 @@ export default function Contributors() {
     setUnaffiliatedCount(unaffiliated.length);
     setAffiliatedOrganizations(affiliated);
     setUnaffiliatedOrganizations(unaffiliated);
+    setLoading(false);
   }, [searchQuery, organizations, showIndexContrib]);
 
   TabPanel.propTypes = {
@@ -275,7 +273,7 @@ export default function Contributors() {
         </Container>
       </Box>
       <Box className='containerGray'>
-        {!loading ? (
+        {loading ? (
           <Box my={12} display='flex' justifyContent='center'>
             <CircularProgress color='secondary' />
           </Box>

--- a/src/pages/Contributors/index.js
+++ b/src/pages/Contributors/index.js
@@ -98,9 +98,6 @@ export default function Contributors() {
           );
           org['totalCount'] = childNodes.length;
         }
-        // if (org.depth === 2) {
-        //   console.log(org)
-        // }
       });
       const names = [];
       let totalAfflCount = 0;

--- a/src/pages/Contributors/index.js
+++ b/src/pages/Contributors/index.js
@@ -104,12 +104,10 @@ export default function Contributors() {
       let totalUnafflCount = 0;
       for (const org of sortedOrgs) {
         names.push(org.name);
-        if (org.name.toLowerCase() !== 'code for all') {
-          if (org.affiliated) {
-            totalAfflCount++;
-          } else {
-            totalUnafflCount++;
-          }
+        if (org.affiliated) {
+          totalAfflCount++;
+        } else {
+          totalUnafflCount++;
         }
       }
       setOrganizations(sortedOrgs);


### PR DESCRIPTION
Fixes
- Reparented orgs that should be outside "Code for All". They are now under siblings of "Code for All"
- Converted hard-coded "Code for All" dropdown to list grandparent orgs
- Converted grandparent org dropdown to use Dropdown component
- Fixed the issue where closing an inner Dropdown list will close the top level dropdown as well
- Tracked parent expanded beyond 6 orgs with component state rather than inside org-tree structure
- Fixed org counts to exclude all parent orgs
- Fixed loading indicator logic
- Updated tests

Suggested future work
- Loading indicator may not be fully working still. I fixed the reversed logic, but didn't try to test it.
- Index contributor indicator icon placement might need to be fixed. Currently, they're shown next to the granparent and parent orgs and not next to the index contributor orgs.
- The way the sub-orgs are counted might need to be fixed. I added code to exclude grandparent and parent orgs from the count. This is to "fix" the discrepancy between the index contributor count saying 8 orgs and the Code for All gp org displaying a count of 9 orgs. It's easy to revert to counting parent and grandparent orgs from here.
- Unaffiliated orgs list might be able to reuse the internals of the Dropdown component. Affiliate orgs is using Dropdown, so it's more consistent if unaffiliate orgs is using the same code.

Closes #1238